### PR TITLE
Update Map.Anim.js

### DIFF
--- a/src/map/Map.Anim.js
+++ b/src/map/Map.Anim.js
@@ -120,8 +120,10 @@ Map.include({
         if (!isNil(props['zoom'])) {
             this.onZoomEnd(props['zoom'][1], zoomOrigin);
         }
-        this._fireEvent(this._animPlayer._interupted ? 'animateinterupted' : 'animateend');
-        delete this._animPlayer;
+        if (this._animPlayer) {
+            this._fireEvent(this._animPlayer._interupted ? 'animateinterupted' : 'animateend');
+            delete this._animPlayer;
+        }
     },
 
     _startAnim(props, zoomOrigin) {


### PR DESCRIPTION
添加对_animPlayer的判断，防止出现拖拽地图动画未结束时单击鱼骨条导致地图导航操作无效的问题