### PR TITLE
fix projection from world point to screen when it's behind camera

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -165,6 +165,19 @@ export function sign(x) {
     return x > 0 ? 1 : -1;
 }
 
+export function log2(x) {
+    if (Math.log2) {
+        return Math.log2(x);
+    }
+    const v = Math.log(x) * Math.LOG2E;
+    const rounded = Math.round(v);
+    if (Math.abs(rounded - v) < 1E-14) {
+        return rounded;
+    } else {
+        return v;
+    }
+}
+
 /*
  * Interpolate between two number.
  *

--- a/src/core/util/vec3.js
+++ b/src/core/util/vec3.js
@@ -1,4 +1,19 @@
 /**
+ * Adds two vec3's
+ *
+ * @param {vec3} out the receiving vector
+ * @param {vec3} a the first operand
+ * @param {vec3} b the second operand
+ * @returns {vec3} out
+ */
+export function add(out, a, b) {
+    out[0] = a[0] + b[0];
+    out[1] = a[1] + b[1];
+    out[2] = a[2] + b[2];
+    return out;
+}
+
+/**
  * Subtracts vector b from vector a
  *
  * @param {vec3} out the receiving vector
@@ -45,6 +60,32 @@ export function normalize(out, a) {
         out[1] = a[1] * len;
         out[2] = a[2] * len;
     }
+    return out;
+}
+
+/**
+ * Calculates the dot product of two vec3's
+ *
+ * @param {vec3} a the first operand
+ * @param {vec3} b the second operand
+ * @returns {Number} dot product of a and b
+ */
+export function dot(a, b) {
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+/**
+ * Scales a vec3 by a scalar number
+ *
+ * @param {vec3} out the receiving vector
+ * @param {vec3} a the vector to scale
+ * @param {Number} b amount to scale the vector by
+ * @returns {vec3} out
+ */
+export function scale(out, a, b) {
+    out[0] = a[0] * b;
+    out[1] = a[1] * b;
+    out[2] = a[2] * b;
     return out;
 }
 

--- a/src/map/Map.Camera.js
+++ b/src/map/Map.Camera.js
@@ -1,6 +1,7 @@
 import Map from './Map';
 import Point from 'geo/Point';
 import * as mat4 from 'core/util/mat4';
+import { subtract, add, scale, normalize, dot } from 'core/util/vec3';
 import { clamp, interpolate, wrap } from 'core/util';
 import { applyMatrix, matrixToQuaternion, quaternionToMatrix, lookAt, setPosition } from 'core/util/math';
 import Browser from 'core/Browser';
@@ -211,11 +212,9 @@ Map.include(/** @lends Map.prototype */{
             //convert altitude at zoom to current zoom
             altitude *= this.getResolution(zoom) / this.getResolution();
             const scale = this._glScale;
-            const t = [point.x * scale, point.y * scale, altitude * scale];
+            let t = [point.x * scale, point.y * scale, altitude * scale];
 
-            // const t2 = [];
-            // applyMatrix(t2, t, this.viewMatrix);
-            // console.log(t2[2]);
+            t = this._projIfBehindCamera(t, this.cameraPosition, this.cameraForward);
 
             applyMatrix(t, t, this.projViewMatrix);
 
@@ -229,8 +228,32 @@ Map.include(/** @lends Map.prototype */{
         }
     },
 
+    // https://forum.unity.com/threads/camera-worldtoscreenpoint-bug.85311/#post-2121212
+    _projIfBehindCamera: function () {
+        const vectorFromCam = new Array(3);
+        const nVectorFromCam = new Array(3);
+        const proj = new Array(3);
+        const sub = new Array(3);
+        return function (position, cameraPos, camForward) {
+            subtract(vectorFromCam, position, cameraPos);
+            const cameraDot = dot(camForward, normalize(nVectorFromCam, vectorFromCam));
+            //const vectorFromCam = position - camera.transform.position;
+            //const camNormDot = dot(camForward, normalize([], vectorFromCam));
+            //if the point is behind the camera then project it onto the camera plane
+            if (cameraDot <= 0) {
+                //we are beind the camera, project the position on the camera plane
+                const camDot = dot(camForward, vectorFromCam);
+                scale(proj, camForward, camDot * 1.01);   //small epsilon to keep the position infront of the camera
+                add(position, cameraPos, subtract(sub, vectorFromCam, proj));
+            }
+
+            return position;
+        };
+    }(),
+
     /**
      * Convert containerPoint at current zoom to 2d point at target zoom
+     * from mapbox-gl-js
      * @param  {Point} p    container point at current zoom
      * @param  {Number} zoom target zoom, current zoom in default
      * @return {Point}      2d point at target zoom
@@ -329,7 +352,8 @@ Map.include(/** @lends Map.prototype */{
 
         const size = this.getSize(),
             scale = this.getGLScale();
-        const center2D = this.cameraLookAt = this._prjToPoint(this._prjCenter, targetZ);
+        const center2D = this._prjToPoint(this._prjCenter, targetZ);
+        this.cameraLookAt = [center2D.x, center2D.y, 0];
 
         const pitch = this.getPitch() * RADIAN;
         const bearing = -this.getBearing() * RADIAN;
@@ -353,6 +377,10 @@ Map.include(/** @lends Map.prototype */{
         const m = this.cameraWorldMatrix || createMat4();
         lookAt(m, [cx, cy, cz], [center2D.x, center2D.y, 0], up);
 
+        const cameraForward = new Array(3);
+        subtract(cameraForward, this.cameraLookAt, this.cameraPosition);
+        // similar with unity's camera.transform.forward
+        this.cameraForward = normalize(cameraForward, cameraForward);
         // math from THREE.js
         const q = {};
         matrixToQuaternion(q, m);

--- a/src/map/Map.Camera.js
+++ b/src/map/Map.Camera.js
@@ -375,7 +375,7 @@ Map.include(/** @lends Map.prototype */{
         const d = dist || 1;
         const up = [Math.sin(bearing) * d, Math.cos(bearing) * d, 0];
         const m = this.cameraWorldMatrix || createMat4();
-        lookAt(m, [cx, cy, cz], [center2D.x, center2D.y, 0], up);
+        lookAt(m, this.cameraPosition, this.cameraLookAt, up);
 
         const cameraForward = new Array(3);
         subtract(cameraForward, this.cameraLookAt, this.cameraPosition);

--- a/src/renderer/geometry/Painter.js
+++ b/src/renderer/geometry/Painter.js
@@ -179,7 +179,7 @@ class Painter extends Class {
         }
         const map = this.getMap(),
             glZoom = map.getGLZoom(),
-            layerPoint = map._pointToContainerPoint(this.getLayer()._getRenderer()._northWest);
+            layerPoint = map._pointToContainerPoint(this.getLayer()._getRenderer()._southWest)._add(0, -map.height);
         let cPoints;
         function pointContainerPoint(point, alt) {
             const p = map._pointToContainerPoint(point, glZoom, alt)._sub(layerPoint);
@@ -253,7 +253,7 @@ class Painter extends Class {
             const c = map.cameraLookAt;
             const pos = map.cameraPosition;
             //add [1px, 1px] towards camera's lookAt
-            extent2D = extent2D.combine(new Point(pos)._add(sign(c.x - pos[0]), sign(c.y - pos[1])));
+            extent2D = extent2D.combine(new Point(pos)._add(sign(c[0] - pos[0]), sign(c[1] - pos[1])));
         }
         const e = this.get2DExtent();
         let clipPoints = points;

--- a/src/renderer/layer/CanvasRenderer.js
+++ b/src/renderer/layer/CanvasRenderer.js
@@ -168,7 +168,7 @@ class CanvasRenderer extends Class {
     remove() {
         this.onRemove();
         delete this._loadingResource;
-        delete this._northWest;
+        delete this._southWest;
         delete this.canvas;
         delete this.context;
         delete this._extent2D;
@@ -196,8 +196,9 @@ class CanvasRenderer extends Class {
      * @return {HTMLCanvasElement}
      */
     getCanvasImage() {
+        const map = this.getMap();
         this._canvasUpdated = false;
-        if (this._renderZoom !== this.getMap().getZoom() || !this.canvas || !this._extent2D) {
+        if (this._renderZoom !== map.getZoom() || !this.canvas || !this._extent2D) {
             return null;
         }
         if (this.isBlank()) {
@@ -206,14 +207,13 @@ class CanvasRenderer extends Class {
         if (this.layer.isEmpty && this.layer.isEmpty()) {
             return null;
         }
-        const map = this.getMap(),
-            size = this._extent2D.getSize(),
-            containerPoint = map._pointToContainerPoint(this._northWest);
+        // size = this._extent2D.getSize(),
+        const containerPoint = map._pointToContainerPoint(this._southWest)._add(0, -map.height);
         return {
             'image': this.canvas,
             'layer': this.layer,
-            'point': containerPoint,
-            'size': size
+            'point': containerPoint/* ,
+            'size': size */
         };
     }
 
@@ -326,7 +326,7 @@ class CanvasRenderer extends Class {
 
     /**
      * Prepare rendering
-     * Set necessary properties, like this._renderZoom/ this._extent2D, this._northWest
+     * Set necessary properties, like this._renderZoom/ this._extent2D, this._southWest
      * @private
      */
     prepareRender() {
@@ -334,7 +334,8 @@ class CanvasRenderer extends Class {
         const map = this.getMap();
         this._renderZoom = map.getZoom();
         this._extent2D = map._get2DExtent();
-        this._northWest = map._containerPointToPoint(new Point(0, 0));
+        //change from northWest to southWest, because northwest's point <=> containerPoint changes when pitch >= 72
+        this._southWest = map._containerPointToPoint(new Point(0, map.height));
     }
 
     /**
@@ -482,13 +483,14 @@ class CanvasRenderer extends Class {
         if (!mask && !this._shouldClip) {
             return false;
         }
-        const old = this._northWest;
-        //when clipping, layer's northwest needs to be reset for mask's containerPoint conversion
-        this._northWest = this.getMap()._containerPointToPoint(new Point(0, 0));
+        const old = this._southWest;
+        const map = this.getMap();
+        //when clipping, layer's southwest needs to be reset for mask's containerPoint conversion
+        this._southWest = map._containerPointToPoint(new Point(0, map.height));
         context.save();
         mask._getPainter().paint(null, context);
         context.clip();
-        this._northWest = old;
+        this._southWest = old;
         if (this.isRenderComplete()) {
             this._shouldClip = false;
         }
@@ -497,14 +499,14 @@ class CanvasRenderer extends Class {
 
     /**
      * Get renderer's current view extent in 2d point
-     * @return {Object} view.extent, view.maskExtent, view.zoom, view.northWest
+     * @return {Object} view.extent, view.maskExtent, view.zoom, view.southWest
      */
     getViewExtent() {
         return {
             'extent' : this._extent2D,
             'maskExtent' : this._maskExtent,
             'zoom' : this._renderZoom,
-            'northWest' : this._northWest
+            'southWest' : this._southWest
         };
     }
 

--- a/src/renderer/layer/ImageGLRenderable.js
+++ b/src/renderer/layer/ImageGLRenderable.js
@@ -1,4 +1,4 @@
-import { IS_NODE, extend, isInteger } from 'core/util';
+import { IS_NODE, extend, isInteger, log2 } from 'core/util';
 import * as mat4 from 'core/util/mat4';
 import Canvas from 'core/Canvas';
 import Browser from 'core/Browser';
@@ -198,7 +198,7 @@ const ImageGLRenderable = Base => {
 
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
 
-            if (isInteger(Math.log2(image.width)) && isInteger(Math.log2(image.width))) {
+            if (isInteger(log2(image.width)) && isInteger(log2(image.width))) {
                 gl.generateMipmap(gl.TEXTURE_2D);
             }
 

--- a/src/renderer/layer/tilelayer/TileLayerCanvasRenderer.js
+++ b/src/renderer/layer/tilelayer/TileLayerCanvasRenderer.js
@@ -400,10 +400,10 @@ class TileLayerCanvasRenderer extends CanvasRenderer {
     _drawBackground() {
         const ctx = this.context;
         const back = this.background;
-        if (back && back.nw && ctx) {
+        if (back && back.southWest && ctx) {
             const map = this.getMap();
             let scale = map._getResolution(back.zoom) / map._getResolution();
-            const cp = map._pointToContainerPoint(back.nw, back.zoom);
+            const cp = map._pointToContainerPoint(back.southWest, back.zoom)._add(0, -map.height * scale);
             const bearing = map.getBearing() - back.bearing;
             if (Browser.retina) {
                 scale *= 1 / 2;
@@ -427,7 +427,7 @@ class TileLayerCanvasRenderer extends CanvasRenderer {
         this.background = {
             canvas : Canvas2D.copy(this.canvas, this._backCanvas),
             zoom : map.getZoom(),
-            nw : this._northWest,
+            southWest : this._southWest,
             bearing : map.getBearing()
         };
     }
@@ -453,7 +453,8 @@ class TileLayerCanvasRenderer extends CanvasRenderer {
 
     onZoomEnd(e) {
         if (this._shouldSaveBack() && this._backRefreshed) {
-            this._northWest = this.getMap()._containerPointToPoint(new Point(0, 0));
+            const map = this.getMap();
+            this._southWest = map._containerPointToPoint(new Point(0, map.height));
             this._saveBackground();
             delete this._backRefreshed;
         }

--- a/src/renderer/layer/tilelayer/TileLayerGLRenderer.js
+++ b/src/renderer/layer/tilelayer/TileLayerGLRenderer.js
@@ -107,7 +107,7 @@ class TileLayerGLRenderer extends ImageGLRenderable(TileLayerCanvasRenderer) {
         if (this.background) {
             if (!this._gl()) {
                 super._drawBackground();
-            } else if (!this.background.nw) {
+            } else if (!this.background.southWest) {
                 //ignore if background is saved in canvas mode
                 const map = this.getMap();
                 const extent = map.getContainerExtent();

--- a/test/layer/CanvasLayerSpec.js
+++ b/test/layer/CanvasLayerSpec.js
@@ -32,7 +32,7 @@ describe('Layer.CanvasLayer', function () {
 
         layer.draw = function (context, view, w, h) {
             expect(view.extent.isValid()).to.be.ok();
-            expect(view.northWest).to.be.ok();
+            expect(view.southWest).to.be.ok();
             expect(view.zoom).to.be.eql(map.getZoom());
             expect(w).to.be.eql(size.width);
             expect(h).to.be.eql(size.height);


### PR DESCRIPTION
This is a fix for #574 .
The reason of the flying lines is due to incorrect projection of the world point (2d point at gl zoom) to the screen when it's behind the camera.

After hours of searching, [a post](https://forum.unity.com/threads/camera-worldtoscreenpoint-bug.85311/#post-2121212) from unity forum saved my ass. Many many thanks to davepoo there.

The fix passes all the specs for now, hope it works.