### PR TITLE
解决maptalks渲染地图在safri下持续拖动缩放导致程序报错直接崩溃的问题

### DIFF
--- a/src/renderer/layer/tilelayer/TileLayerCanvasRenderer.js
+++ b/src/renderer/layer/tilelayer/TileLayerCanvasRenderer.js
@@ -640,8 +640,8 @@ class TileLayerCanvasRenderer extends CanvasRenderer {
         if (!tile || !tile.image) {
             return;
         }
-        delete tile.image.onload;
-        delete tile.image.onerror;
+        tile.image.onload = null;
+        tile.image.onerror = null;
     }
 
     _generatePlaceHolder(z) {


### PR DESCRIPTION
#694 解决maptalks渲染地图在safri下持续拖动缩放导致程序报错直接崩溃的问题