### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Download the [lastest release](https://github.com/maptalks/maptalks.js/releases)
 <script src="path/to/maptalks.min.js" type="text/javascript"></script>
 ```
 
+* CDN
+Just include this in your html:
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/maptalks/dist/maptalks.min.css">
+<script src="https://cdn.jsdelivr.net/npm/maptalks/dist/maptalks.min.js"></script>
+```
+
 * NPM
 
 ```shell


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/maptalks) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.