### PR TITLE
fix Map distance tool can't be disabled correctly #865

### DIFF
--- a/src/map/tool/DistanceTool.js
+++ b/src/map/tool/DistanceTool.js
@@ -213,6 +213,7 @@ class DistanceTool extends DrawTool {
         }).addTo(this._measureMarkerLayer);
         const content = (this.options['language'] === 'zh-CN' ? '起点' : 'start');
         const startLabel = new Label(content, param['coordinate'], this.options['labelOptions']);
+        this._lastVertex = startLabel;
         this._measureMarkerLayer.addGeometry(startLabel);
     }
 


### PR DESCRIPTION
When map distance tool draws starting vertex, set DistanceTool._lastVertex = starting vertex.