### PR TITLE
ScaleControl 的 padding 设置为0px

### DIFF
--- a/src/control/Control.Scale.js
+++ b/src/control/Control.Scale.js
@@ -58,7 +58,7 @@ class Scale extends Control {
     }
 
     _addScales() {
-        const css = 'border: 2px solid #000000;border-top: none;line-height: 1.1;padding: 2px 5px 1px;' +
+        const css = 'border: 2px solid #000000;border-top: none;line-height: 1.1;padding: 0px;' +
             'color: #000000;font-size: 11px;text-align:center;white-space: nowrap;overflow: hidden' +
             ';-moz-box-sizing: content-box;box-sizing: content-box;background: #fff; background: rgba(255, 255, 255, 0);';
         if (this.options['metric']) {


### PR DESCRIPTION
ScaleControl 的 padding  由 2px 5px 1px;  更改为 0px;
ScaleControl 设置 padding  后和实际尺寸相比存在视觉上的偏差，所以padding  设置为0px;