### PR TITLE
fix dom plugins which don't have checkAndDraw

### DIFF
--- a/src/renderer/map/MapCanvasRenderer.js
+++ b/src/renderer/map/MapCanvasRenderer.js
@@ -143,7 +143,12 @@ class MapCanvasRenderer extends MapRenderer {
                 if (renderer.prepareRender) {
                     renderer.prepareRender();
                 }
-                renderer.checkAndDraw(renderer.drawOnInteracting, this._eventParam, framestamp);
+                if (renderer.checkAndDraw) {
+                    // for canvas renderers
+                    renderer.checkAndDraw(renderer.drawOnInteracting, this._eventParam, framestamp);
+                } else {
+                    renderer.drawOnInteracting(this._eventParam, framestamp);
+                }
             } else {
                 // map is not interacting, call layer's render
                 renderer.render(framestamp);
@@ -221,7 +226,12 @@ class MapCanvasRenderer extends MapRenderer {
             // call drawOnInteracting to redraw the layer
             renderer.prepareRender();
             renderer.prepareCanvas();
-            renderer.checkAndDraw(renderer.drawOnInteracting, this._eventParam, framestamp);
+            if (renderer.checkAndDraw) {
+                // for canvas renderers
+                renderer.checkAndDraw(renderer.drawOnInteracting, this._eventParam, framestamp);
+            } else {
+                renderer.drawOnInteracting(this._eventParam, framestamp);
+            }
             return drawTime;
         } else if (map.isZooming() && !map.getPitch() && !map.isRotating()) {
             // when:


### PR DESCRIPTION
some old dom based plugins doesn't have checkAndDraw method, this is to make sure they can work.