### PR TITLE
fix wrong fullscreen api call

### DIFF
--- a/src/map/Map.FullScreen.js
+++ b/src/map/Map.FullScreen.js
@@ -58,8 +58,8 @@ Map.include(/** @lends Map.prototype */ {
     },
 
     _requestFullScreen(dom) {
-        if (dom.requestFullScreen) {
-            dom.requestFullScreen();
+        if (dom.requestFullscreen) {
+            dom.requestFullscreen();
         } else if (dom.mozRequestFullScreen) {
             dom.mozRequestFullScreen();
         } else if (dom.webkitRequestFullScreen) {
@@ -80,8 +80,8 @@ Map.include(/** @lends Map.prototype */ {
     },
 
     _cancelFullScreen() {
-        if (document.cancelFullScreen) {
-            document.cancelFullScreen();
+        if (document.exitFullscreen) {
+            document.exitFullscreen();
         } else if (document.mozCancelFullScreen) {
             document.mozCancelFullScreen();
         } else if (document.webkitCancelFullScreen) {


### PR DESCRIPTION
wrong fullscreen api in Map.FullScreen.js, refer to [Fullscreen_API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API) for details!