### PR TITLE
fix rendering issues caused by sublayer remove of GroupTileLayer

### DIFF
--- a/src/layer/tile/GroupTileLayer.js
+++ b/src/layer/tile/GroupTileLayer.js
@@ -187,7 +187,7 @@ class GroupTileLayer extends TileLayer {
         let count = 0;
         for (let i = 0, l = layers.length; i < l; i++) {
             const layer = layers[i];
-            if (!layer.options['visible']) {
+            if (!layer.options['visible'] || !layer.getMap()) {
                 continue;
             }
             const childGrid = layer.getTiles(z, parentLayer || this);


### PR DESCRIPTION
It should be skipped when calling getTiles after the child Layer of GroupTileLayer is deleted reason:

1.remove of the layer may happen before the frameend