### PR TITLE
Fix the problem that  the child layer's maxZoom setting is invalid

### DIFF
--- a/src/layer/tile/GroupTileLayer.js
+++ b/src/layer/tile/GroupTileLayer.js
@@ -187,7 +187,7 @@ class GroupTileLayer extends TileLayer {
         let count = 0;
         for (let i = 0, l = layers.length; i < l; i++) {
             const layer = layers[i];
-            if (!layer.options['visible'] || !layer.getMap()) {
+            if (!layer.isVisible()  || !layer.getMap()) {
                 continue;
             }
             const childGrid = layer.getTiles(z, parentLayer || this);


### PR DESCRIPTION
当GroupTileLayer拥有多个TileLayer,且子图层分别设置了不同的maxZoom时，设置不会起效，且地图会被maxZoom小的图层一直遮盖。
初学，不知修改是否合理