### PR TITLE
adapt adsorption plugin

### DIFF
--- a/src/geometry/editor/GeometryEditor.js
+++ b/src/geometry/editor/GeometryEditor.js
@@ -919,9 +919,9 @@ class GeometryEditor extends Eventable(Class) {
 
         function moveVertexHandle(handleConatainerPoint, index, ringIndex = 0) {
             //for adsorption effect
-            const adsorb = me._geometry.adsorb;
-            if (adsorb && isFunction(adsorb)) {
-                handleConatainerPoint = me._geometry.adsorb(handleConatainerPoint) || handleConatainerPoint;
+            const snapTo = me._geometry.snapTo;
+            if (snapTo && isFunction(snapTo)) {
+                handleConatainerPoint = me._geometry.snapTo(handleConatainerPoint) || handleConatainerPoint;
             }
             const vertice = getVertexPrjCoordinates(ringIndex);
             const nVertex = map._containerPointToPrj(handleConatainerPoint.sub(getDxDy()));

--- a/src/geometry/editor/GeometryEditor.js
+++ b/src/geometry/editor/GeometryEditor.js
@@ -919,9 +919,9 @@ class GeometryEditor extends Eventable(Class) {
 
         function moveVertexHandle(handleConatainerPoint, index, ringIndex = 0) {
             //for adsorption effect
-            const adsorbent = me._geometry.adsorbent;
-            if (adsorbent && isFunction(adsorbent)) {
-                handleConatainerPoint = me._geometry.adsorbent(handleConatainerPoint) || handleConatainerPoint;
+            const adsorb = me._geometry.adsorb;
+            if (adsorb && isFunction(adsorb)) {
+                handleConatainerPoint = me._geometry.adsorb(handleConatainerPoint) || handleConatainerPoint;
             }
             const vertice = getVertexPrjCoordinates(ringIndex);
             const nVertex = map._containerPointToPrj(handleConatainerPoint.sub(getDxDy()));

--- a/src/geometry/editor/GeometryEditor.js
+++ b/src/geometry/editor/GeometryEditor.js
@@ -1,5 +1,5 @@
 import { INTERNAL_LAYER_PREFIX } from '../../core/Constants';
-import { isNil, isNumber, sign, removeFromArray, UID } from '../../core/util';
+import { isNil, isNumber, sign, removeFromArray, UID, isFunction } from '../../core/util';
 import { lowerSymbolOpacity } from '../../core/util/style';
 import Class from '../../core/Class';
 import Eventable from '../../core/Eventable';
@@ -918,6 +918,11 @@ class GeometryEditor extends Eventable(Class) {
         }
 
         function moveVertexHandle(handleConatainerPoint, index, ringIndex = 0) {
+            //for adsorption effect
+            const adsorbent = me._geometry.adsorbent;
+            if (adsorbent && isFunction(adsorbent)) {
+                handleConatainerPoint = me._geometry.adsorbent(handleConatainerPoint) || handleConatainerPoint;
+            }
             const vertice = getVertexPrjCoordinates(ringIndex);
             const nVertex = map._containerPointToPrj(handleConatainerPoint.sub(getDxDy()));
             const pVertex = vertice[index];

--- a/src/map/tool/DrawTool.js
+++ b/src/map/tool/DrawTool.js
@@ -376,10 +376,10 @@ class DrawTool extends MapTool {
             this._createGeometry(event);
         } else {
             let prjCoord = this.getMap()._pointToPrj(event['point2d']);
-            const adsorbent = this._geometry.adsorbent;
+            const adsorb = this._geometry.adsorb;
             //for adsorption effect
-            if (adsorbent && isFunction(adsorbent)) {
-                const containerPoint = this._geometry.adsorbent(event.containerPoint) || event.containerPoint;
+            if (adsorb && isFunction(adsorb)) {
+                const containerPoint = this._geometry.adsorb(event.containerPoint) || event.containerPoint;
                 prjCoord = this.getMap()._containerPointToPrj(containerPoint);
             }
             if (!isNil(this._historyPointer)) {
@@ -470,8 +470,8 @@ class DrawTool extends MapTool {
             return;
         }
         let prjCoord = this.getMap()._pointToPrj(event['point2d']);
-        if (this._geometry.adsorbent) {
-            containerPoint = this._geometry.adsorbent(containerPoint) || containerPoint;
+        if (this._geometry.adsorb) {
+            containerPoint = this._geometry.adsorb(containerPoint) || containerPoint;
             prjCoord = map._containerPointToPrj(containerPoint);
         }
         const projection = map.getProjection();

--- a/src/map/tool/DrawTool.js
+++ b/src/map/tool/DrawTool.js
@@ -376,10 +376,10 @@ class DrawTool extends MapTool {
             this._createGeometry(event);
         } else {
             let prjCoord = this.getMap()._pointToPrj(event['point2d']);
-            const adsorb = this._geometry.adsorb;
+            const snapTo = this._geometry.snapTo;
             //for adsorption effect
-            if (adsorb && isFunction(adsorb)) {
-                const containerPoint = this._geometry.adsorb(event.containerPoint) || event.containerPoint;
+            if (snapTo && isFunction(snapTo)) {
+                const containerPoint = this._geometry.snapTo(event.containerPoint) || event.containerPoint;
                 prjCoord = this.getMap()._containerPointToPrj(containerPoint);
             }
             if (!isNil(this._historyPointer)) {
@@ -470,8 +470,8 @@ class DrawTool extends MapTool {
             return;
         }
         let prjCoord = this.getMap()._pointToPrj(event['point2d']);
-        if (this._geometry.adsorb) {
-            containerPoint = this._geometry.adsorb(containerPoint) || containerPoint;
+        if (this._geometry.snapTo) {
+            containerPoint = this._geometry.snapTo(containerPoint) || containerPoint;
             prjCoord = map._containerPointToPrj(containerPoint);
         }
         const projection = map.getProjection();

--- a/src/map/tool/DrawTool.js
+++ b/src/map/tool/DrawTool.js
@@ -1,5 +1,5 @@
 import { INTERNAL_LAYER_PREFIX } from '../../core/Constants';
-import { isNil } from '../../core/util';
+import { isFunction, isNil } from '../../core/util';
 import { extendSymbol } from '../../core/util/style';
 import { getExternalResources } from '../../core/util/resource';
 import { stopPropagation } from '../../core/util/dom';
@@ -375,7 +375,13 @@ class DrawTool extends MapTool {
         if (!this._geometry) {
             this._createGeometry(event);
         } else {
-            const prjCoord = this.getMap()._pointToPrj(event['point2d']);
+            let prjCoord = this.getMap()._pointToPrj(event['point2d']);
+            const adsorbent = this._geometry.adsorbent;
+            //for adsorption effect
+            if (adsorbent && isFunction(adsorbent)) {
+                const containerPoint = this._geometry.adsorbent(event.containerPoint) || event.containerPoint;
+                prjCoord = this.getMap()._containerPointToPrj(containerPoint);
+            }
             if (!isNil(this._historyPointer)) {
                 this._clickCoords = this._clickCoords.slice(0, this._historyPointer);
             }
@@ -459,11 +465,15 @@ class DrawTool extends MapTool {
         if (!this._geometry || !map || map.isInteracting()) {
             return;
         }
-        const containerPoint = this._getMouseContainerPoint(event);
+        let containerPoint = this._getMouseContainerPoint(event);
         if (!this._isValidContainerPoint(containerPoint)) {
             return;
         }
-        const prjCoord = this.getMap()._pointToPrj(event['point2d']);
+        let prjCoord = this.getMap()._pointToPrj(event['point2d']);
+        if (this._geometry.adsorbent) {
+            containerPoint = this._geometry.adsorbent(containerPoint) || containerPoint;
+            prjCoord = map._containerPointToPrj(containerPoint);
+        }
         const projection = map.getProjection();
         event.drawTool = this;
         const registerMode = this._getRegisterMode();
@@ -616,7 +626,7 @@ class DrawTool extends MapTool {
         if (!drawToolLayer) {
             drawToolLayer = new VectorLayer(drawLayerId, {
                 'enableSimplify': false,
-                'enableAltitude' : this.options['enableAltitude']
+                'enableAltitude': this.options['enableAltitude']
             });
             this._map.addLayer(drawToolLayer);
         }
@@ -629,6 +639,7 @@ class DrawTool extends MapTool {
         }
         if (this._geometry) {
             param['geometry'] = this._getRegisterMode()['generate'](this._geometry, { drawTool: this });
+            param.tempGeometry = this._geometry;
         }
         MapTool.prototype._fireEvent.call(this, eventName, param);
     }


### PR DESCRIPTION
为吸附效果插件进行必要的代码适配  https://github.com/deyihu/maptalks-adsorption

因为编辑和绘制，逻辑全部在内部，插件代码不好注入进来，解决方法有:

- 核心库直接集成这个功能
- 核心库做下必要的适配，为插件服务

目前采用的是第二种方式,核心的思路：有吸附插件动态计算鼠标位置的经纬度（满足吸附条件，即使鼠标位置变了，但是其实际的坐标任然不变），而不再是有鼠标的实时位置决定