### PR TITLE
fix GeometryCollection toJSON error when children has Circle etc

### DIFF
--- a/src/geometry/GeoJSON.js
+++ b/src/geometry/GeoJSON.js
@@ -148,7 +148,7 @@ const GeoJSON = {
                 //circle ellipse etc...
                 //规范上geojson里是没有Circle等图形的，但是Circle json等的反序列化有用到该方法
                 if (geometries[i].subType) {
-                    mGeos.push(Geometry.getJSONClass(json['subType']).fromJSON(geometries[i]));
+                    mGeos.push(Geometry.getJSONClass(geometries[i].subType).fromJSON(geometries[i]));
                 } else {
                     mGeos.push(GeoJSON._convert(geometries[i]));
                 }

--- a/src/geometry/GeoJSON.js
+++ b/src/geometry/GeoJSON.js
@@ -12,6 +12,7 @@ import MultiPoint from './MultiPoint';
 import MultiLineString from './MultiLineString';
 import MultiPolygon from './MultiPolygon';
 import GeometryCollection from './GeometryCollection';
+import Geometry from './Geometry';
 
 const types = {
     'Marker': Marker,
@@ -144,7 +145,13 @@ const GeoJSON = {
             const mGeos = [];
             const size = geometries.length;
             for (let i = 0; i < size; i++) {
-                mGeos.push(GeoJSON._convert(geometries[i]));
+                //circle ellipse etc...
+                //规范上geojson里是没有Circle等图形的，但是Circle json等的反序列化有用到该方法
+                if (geometries[i].subType) {
+                    mGeos.push(Geometry.getJSONClass(json['subType']).fromJSON(geometries[i]));
+                } else {
+                    mGeos.push(GeoJSON._convert(geometries[i]));
+                }
             }
             const result = new GeometryCollection(mGeos);
             if (foreachFn) {

--- a/src/geometry/GeometryCollection.js
+++ b/src/geometry/GeometryCollection.js
@@ -410,12 +410,19 @@ class GeometryCollection extends Geometry {
     _toJSON(options) {
         //Geometry了用的是toGeoJSON(),如果里面包含特殊图形(Circle等),就不能简单的用toGeoJSON代替了，否则反序列化回来就不是原来的图形了
         const feature = {
-            'type': 'GeometryCollection',
-            'geometries': this.getGeometries().filter(geo => {
-                return geo && geo._toJSON;
-            }).map(geo => {
-                return geo._toJSON();
-            })
+            'type': 'Feature',
+            'geometry': {
+                'type': 'GeometryCollection',
+                'geometries': this.getGeometries().filter(geo => {
+                    return geo && geo._toJSON;
+                }).map(geo => {
+                    const json = geo._toJSON();
+                    if (json.subType) {
+                        return json;
+                    }
+                    return geo._exportGeoJSONGeometry();
+                })
+            }
         };
         options.feature = feature;
         return options;

--- a/src/geometry/GeometryCollection.js
+++ b/src/geometry/GeometryCollection.js
@@ -389,6 +389,7 @@ class GeometryCollection extends Geometry {
         return result;
     }
 
+    //for toGeoJSON
     _exportGeoJSONGeometry() {
         const children = [];
         if (!this.isEmpty()) {
@@ -404,6 +405,20 @@ class GeometryCollection extends Geometry {
             'type': 'GeometryCollection',
             'geometries': children
         };
+    }
+    //for toJSON
+    _toJSON(options) {
+        //Geometry了用的是toGeoJSON(),如果里面包含特殊图形(Circle等),就不能简单的用toGeoJSON代替了，否则反序列化回来就不是原来的图形了
+        const feature = {
+            'type': 'GeometryCollection',
+            'geometries': this.getGeometries().filter(geo => {
+                return geo && geo._toJSON;
+            }).map(geo => {
+                return geo._toJSON();
+            })
+        };
+        options.feature = feature;
+        return options;
     }
 
     _clearProjection() {
@@ -513,6 +528,13 @@ class GeometryCollection extends Geometry {
         }
         return true;
     }
+
+    // copy() {
+    //     const geometries = this.getGeometries().map(geo => {
+    //         return geo.copy();
+    //     });
+    //     return new GeometryCollection(geometries, extend({}, this.options));
+    // }
 }
 
 GeometryCollection.registerJSONType('GeometryCollection');

--- a/src/geometry/MultiGeometry.js
+++ b/src/geometry/MultiGeometry.js
@@ -77,6 +77,12 @@ class MultiGeometry extends GeometryCollection {
             'coordinates': coordinates
         };
     }
+
+    _toJSON(options) {
+        return {
+            'feature': this.toGeoJSON(options)
+        };
+    }
 }
 
 export default MultiGeometry;

--- a/src/map/Map.Profile.js
+++ b/src/map/Map.Profile.js
@@ -59,6 +59,7 @@ Geometry.fromJSON = function (json) {
             geometry.setId(json['feature']['id']);
         }
     } else {
+        //feature可能是GeometryCollection，里面可能包含Circle等
         geometry = GeoJSON.toGeometry(json['feature']);
         if (json['options']) {
             geometry.config(json['options']);


### PR DESCRIPTION
fix #1780 

- 原来 GeometryCollection里面如果包含Circle,
toJSON会把Circle格式化成Polygon，
反序列化后，那么图形就不是Circle,是Polygon

- 该PR可以让GeometryCollection 里的Circle等支持反序列化回来
- 因为GeoJSON有这个严格定义，所有toGeoJSON仍然保持着原来的逻辑（Circle会被序列化成Polyong）

