### PR TITLE
dom and Eventable Adding a duplicate listening function is to warn

### DIFF
--- a/src/core/Eventable.js
+++ b/src/core/Eventable.js
@@ -49,6 +49,7 @@ const Eventable = Base =>
                 if (l > 0) {
                     for (let i = 0; i < l; i++) {
                         if (handler === handlerChain[i].handler && handlerChain[i].context === context) {
+                            console.warn(this, `find '${eventsOn}' handler:`, handler, ' The old listener function will be removed');
                             return this;
                         }
                     }

--- a/src/core/util/dom.js
+++ b/src/core/util/dom.js
@@ -6,7 +6,7 @@
  * @name DomUtil
  */
 
-import Browser from  '../Browser';
+import Browser from '../Browser';
 import { IS_NODE } from './env';
 import { isString, isNil } from './common';
 import { splitWords } from './strings';
@@ -165,6 +165,7 @@ export function addDomEvent(obj, typeArr, handler, context) {
         }
         const hit = listensDomEvent(obj, type, handler);
         if (hit >= 0) {
+            console.warn(obj, `find '${type}' handler:`, handler, ' The old listener function will be removed');
             removeDomEvent(obj, type, handler);
         }
         obj['Z__' + type].push({

--- a/src/handler/Drag.js
+++ b/src/handler/Drag.js
@@ -77,9 +77,12 @@ class DragHandler extends Handler {
         delete this.moved;
         const actual = event.touches ? event.touches[0] : event;
         this.startPos = new Point(actual.clientX, actual.clientY);
+        off(document, MOVE_EVENTS[event.type], this.onMouseMove, this);
+        off(document, END_EVENTS[event.type], this.onMouseUp, this);
         on(document, MOVE_EVENTS[event.type], this.onMouseMove, this);
         on(document, END_EVENTS[event.type], this.onMouseUp, this);
         if (!this.options['ignoreMouseleave']) {
+            off(this.dom, 'mouseleave', this.onMouseUp, this);
             on(this.dom, 'mouseleave', this.onMouseUp, this);
         }
         this.fire('mousedown', {


### PR DESCRIPTION
fix #1786

- 目前的事件机制，当用户对同一个事件进行多次（handler相同）监听时，会把老的监听给移除，这个行为是静默的，导致用户发现不了自己上一次监听的函数给移除掉了
- 有时用户确实想要多次监听，但是因为默认把老的移除掉，用户根本发现不了，导致用户一直以为自己写的代码没有问题

**该问题已经导致多次事故发生**

https://github.com/maptalks/maptalks.js/commit/c5a547a464ee97eff15ec453357b7f1acc261d7a

https://github.com/maptalks/maptalks.three/commit/3ecbc428f6c2b51f792e0b6f9bceba1f6c2e2378

发生的原因：
当监听事件是原型方法时，就会出现问题，
举例：

```js
 class A {
  hello(){

   }
}

const a1=new A();
const a2=new A();

on('click',a1.hello,a1);
on('click',a2.hello,a2);

```

其中a1和a2 都是A的实例，他们的hello方法其实是相等的，导致第一次监听失效，所以应该给予提示，告诉用户自己的代码有问题
