### PR TITLE
修复删除挖孔无效的问题

### DIFF
--- a/src/geometry/Polygon.js
+++ b/src/geometry/Polygon.js
@@ -82,6 +82,8 @@ class Polygon extends Path {
                     holes.push(this._trimRing(rings[i]));
                 }
                 this._holes = holes;
+            } else {
+                this._holes = null;
             }
         }
 


### PR DESCRIPTION
通过 setCoordinates 移除多边形中的挖孔时，没有清空之前的 this._holes，导致无法删除