### PR TITLE
map add preventTouch config

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -141,7 +141,8 @@ const options = {
     'clickTimeThreshold': 280,
 
     'stopRenderOnOffscreen': true,
-    'preventWheelScroll': true
+    'preventWheelScroll': true,
+    'preventTouch': true,
 };
 
 /**

--- a/src/map/handler/Map.GeometryEvents.js
+++ b/src/map/handler/Map.GeometryEvents.js
@@ -199,7 +199,9 @@ class MapGeometryEventsHandler extends Handler {
         }
         const containerPoint = getEventContainerPoint(actual, map._containerDOM);
         if (eventType === 'touchstart') {
-            preventDefault(domEvent);
+            if (map.options['preventTouch']) {
+                preventDefault(domEvent);
+            }
         }
 
         let geometryCursorStyle = null;

--- a/src/map/handler/Map.Touch.js
+++ b/src/map/handler/Map.Touch.js
@@ -34,7 +34,9 @@ class MapTouchZoomHandler extends Handler {
         off(document, 'touchend', this._onTouchEnd, this);
         addDomEvent(document, 'touchmove', this._onTouchMove, this);
         addDomEvent(document, 'touchend', this._onTouchEnd, this);
-        preventDefault(event);
+        if (map.options['preventTouch']) {
+            preventDefault(event);
+        }
 
         /**
           * touchactstart event


### PR DESCRIPTION
fix #1941 

场景：用户禁用地图拖拽后，滑动地图可以冒泡