### PR TITLE
fix tile's stencil value

### DIFF
--- a/src/renderer/layer/tilelayer/TileLayerGLRenderer.js
+++ b/src/renderer/layer/tilelayer/TileLayerGLRenderer.js
@@ -96,7 +96,7 @@ class TileLayerGLRenderer extends ImageGLRenderable(TileLayerCanvasRenderer) {
             debugInfo =  this.getDebugInfo(tileInfo.id);
         }
         const gl = this.gl;
-        gl.stencilFunc(gl.LESS, this.drawingCurrentTiles ? 0 : 1 + Math.abs(this.getCurrentTileZoom() - tileInfo.z), 0xFF);
+        gl.stencilFunc(gl.LEQUAL, Math.abs(this.getCurrentTileZoom() - tileInfo.z), 0xFF);
         const layerPolygonOffset = this.layer.getPolygonOffset();
         const polygonOffset = this.drawingCurrentTiles ? layerPolygonOffset - 1 : layerPolygonOffset;
         gl.polygonOffset(polygonOffset, polygonOffset);


### PR DESCRIPTION
原有的stencil值会造成GroupTileLayer中，第一个图层的瓦片stencil覆盖掉第二个图层的瓦片，导致第二个图层的瓦片无法绘制