### PR TITLE
add lineDashOffset in symbol option for line geo

### DIFF
--- a/src/core/Canvas.js
+++ b/src/core/Canvas.js
@@ -105,6 +105,9 @@ const Canvas = {
         if (ctx.setLineDash && isArrayHasData(style['lineDasharray'])) {
             ctx.setLineDash(style['lineDasharray']);
         }
+        if (style['lineDashOffset']) {
+            ctx.lineDashOffset = style['lineDashOffset'];
+        }
         const polygonPattern = style['polygonPatternFile'];
         let fill = style['polygonFill'] || DEFAULT_FILL_COLOR;
         if (testing) {

--- a/src/core/Canvas.js
+++ b/src/core/Canvas.js
@@ -105,9 +105,7 @@ const Canvas = {
         if (ctx.setLineDash && isArrayHasData(style['lineDasharray'])) {
             ctx.setLineDash(style['lineDasharray']);
         }
-        if (style['lineDashOffset']) {
-            ctx.lineDashOffset = style['lineDashOffset'];
-        }
+        ctx.lineDashOffset = style['lineDashOffset'] || 0;
         const polygonPattern = style['polygonPatternFile'];
         let fill = style['polygonFill'] || DEFAULT_FILL_COLOR;
         if (testing) {

--- a/src/renderer/geometry/symbolizers/StrokeAndFillSymbolizer.js
+++ b/src/renderer/geometry/symbolizers/StrokeAndFillSymbolizer.js
@@ -142,6 +142,7 @@ export default class StrokeAndFillSymbolizer extends CanvasSymbolizer {
             'lineWidth': getValueOrDefault(s['lineWidth'], 2),
             'lineOpacity': getValueOrDefault(s['lineOpacity'], 1),
             'lineDasharray': getValueOrDefault(s['lineDasharray'], []),
+            'lineDashOffset': getValueOrDefault(s['lineDashOffset'], 0),
             'lineCap': getValueOrDefault(s['lineCap'], 'butt'), //“butt”, “square”, “round”
             'lineJoin': getValueOrDefault(s['lineJoin'], 'miter'), //“bevel”, “round”, “miter”
             'linePatternFile': getValueOrDefault(s['linePatternFile'], null),


### PR DESCRIPTION
Add a line symbol 'lineDashOffset ' for line dash offset. [Ant line](https://img1.imgtp.com/2023/08/14/jeCTMcFC.gif) can be achieved with this:
`const lineLayer = new maptalks.VectorLayer("line", data, {
    style: {
        symbol: {
            lineColor: 'red',
            lineWidth: 2,
            lineDasharray: [5, 5],
            lineDashOffset: 0
        }
    }
}).addTo(map)
lineLayer.getLastGeometry().animate({
    symbol: {
        lineDashOffset: -20
    }
}, {
    duration: 1000,
    repeat: true
})`