### PR TITLE
add terrain tile mode for TileLayer

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -109,7 +109,7 @@ export function parseJSON(str) {
 export function pushIn(dest) {
     for (let i = 1; i < arguments.length; i++) {
         const src = arguments[i];
-        if (src) {
+        if (src && src.length) {
             for (let ii = 0, ll = src.length; ii < ll; ii++) {
                 dest.push(src[ii]);
             }

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -401,6 +401,7 @@ class Layer extends JSONAble(Eventable(Renderable(Class))) {
         if (this.map) {
             this.map.removeLayer(this);
         }
+        this.fire('remove');
         return this;
     }
 

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -400,6 +400,10 @@ class Layer extends JSONAble(Eventable(Renderable(Class))) {
     remove() {
         if (this.map) {
             this.map.removeLayer(this);
+            const renderer = this.map.getRenderer();
+            if (renderer) {
+                renderer.setToRedraw();
+            }
         }
         this.fire('remove');
         return this;

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -404,8 +404,9 @@ class Layer extends JSONAble(Eventable(Renderable(Class))) {
             if (renderer) {
                 renderer.setToRedraw();
             }
+        } else {
+            this.fire('remove');
         }
-        this.fire('remove');
         return this;
     }
 

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -399,8 +399,8 @@ class Layer extends JSONAble(Eventable(Renderable(Class))) {
      */
     remove() {
         if (this.map) {
-            this.map.removeLayer(this);
             const renderer = this.map.getRenderer();
+            this.map.removeLayer(this);
             if (renderer) {
                 renderer.setToRedraw();
             }

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -144,7 +144,7 @@ const options = {
     'tileLimitPerFrame': 0,
 
     'tileStackStartDepth': 7,
-    'tileStackDepth': 3,
+    'tileStackDepth': 5,
 
     'awareOfTerrain': true
 };
@@ -353,7 +353,7 @@ class TileLayer extends Layer {
             z = this._getTileZoom(map.getZoom());
         }
         const sr = this.getSpatialReference();
-        const maxZoom = Math.min(z, this.getMaxZoom(), this.options['maxAvailableZoom'] || Infinity);
+        const maxZoom = Math.min(z, this.getMaxZoom(), this.getMaxAvailableZoom() || Infinity);
         const projectionView = map.projViewMatrix;
         const fullExtent = this._getTileFullExtent();
 
@@ -873,7 +873,7 @@ class TileLayer extends Layer {
             const dz = Math.log(res1 / res0) * Math.LOG2E; // polyfill of Math.log2
             zoom += dz;
         }
-        const maxZoom = this.options['maxAvailableZoom'];
+        const maxZoom = this.getMaxAvailableZoom();
         if (!isNil(maxZoom) && zoom > maxZoom) {
             zoom = maxZoom;
         }
@@ -884,6 +884,15 @@ class TileLayer extends Layer {
         return zoom;
     }
 
+    /**
+     * Get tileLayer's max available zoom, either options['maxAvailableZoom'] or spatialReference's maxZoom
+     *
+     * @returns {Number}
+     **/
+    getMaxAvailableZoom() {
+        const sr = this.getSpatialReference();
+        return this.options['maxAvailableZoom'] || sr && sr.getMaxZoom();
+    }
 
     _getTiles(tileZoom, containerExtent, cascadeLevel, parentRenderer, ignoreMinZoom) {
         // rendWhenReady = false;
@@ -1204,6 +1213,10 @@ class TileLayer extends Layer {
             offset = [offset, offset];
         }
         return offset || [0, 0];
+    }
+
+    getTileId(x, y, zoom, id) {
+        return this._getTileId(x, y, zoom, id);
     }
 
     _getTileId(x, y, zoom, id) {

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -499,6 +499,7 @@ class TileLayer extends Layer {
                         extent = new PointExtent(swx, swy, swx + width, swy + height);
                     }
                     childNode = {
+                        parent: node.id,
                         x: childX,
                         y: childY,
                         idx: childIdx,

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -1203,11 +1203,11 @@ class TileLayer extends Layer {
         return tileInfo;
     }
 
-    _getTileOffset(z) {
+    _getTileOffset(...params) {
         // offset result can't be cached, as it varies with map's center.
         let offset = this.options['offset'];
         if (isFunction(offset)) {
-            offset = offset.call(this, z);
+            offset = offset.call(this, ...params);
         }
         if (isNumber(offset)) {
             offset = [offset, offset];

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1292,11 +1292,11 @@ class Map extends Handlerable(Eventable(Renderable(Class))) {
             if (renderer) {
                 renderer.setLayerCanvasUpdated();
             }
-            // this.once('frameend', () => {
-            //     removed.forEach(layer => {
-            //         layer.fire('remove');
-            //     });
-            // });
+            this.once('frameend', () => {
+                removed.forEach(layer => {
+                    layer.fire('remove');
+                });
+            });
         }
         /**
          * removelayer event, fired when removing layers.

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1292,9 +1292,6 @@ class Map extends Handlerable(Eventable(Renderable(Class))) {
             if (renderer) {
                 renderer.setLayerCanvasUpdated();
             }
-            removed.forEach(layer => {
-                layer.fire('remove');
-            });
             // this.once('frameend', () => {
             //     removed.forEach(layer => {
             //         layer.fire('remove');

--- a/src/renderer/layer/ImageGLRenderable.js
+++ b/src/renderer/layer/ImageGLRenderable.js
@@ -133,8 +133,11 @@ const ImageGLRenderable = Base => {
             v2[1] = 2;
             v2[2] = image.glBuffer.type;
             this.enableVertexAttrib(v2); // ['a_position', 3]
-            // gl.bindBuffer(gl.ARRAY_BUFFER, this.texBuffer);
-            // this.enableVertexAttrib(['a_texCoord', 2, 'UNSIGNED_BYTE']);
+            gl.bindBuffer(gl.ARRAY_BUFFER, this.texBuffer);
+            v2[0] = 'a_texCoord';
+            v2[1] = 2;
+            v2[2] = 'UNSIGNED_BYTE';
+            this.enableVertexAttrib(v2);
             gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
 
             if (debug) {

--- a/src/renderer/layer/ImageGLRenderable.js
+++ b/src/renderer/layer/ImageGLRenderable.js
@@ -192,6 +192,8 @@ const ImageGLRenderable = Base => {
                 x2, y2
             ), gl.DYNAMIC_DRAW);
             gl.uniform1f(this.program['u_debug_line'], 0);
+            gl.bindBuffer(gl.ARRAY_BUFFER, this.texBuffer);
+            this.enableVertexAttrib(['a_texCoord', 2, 'UNSIGNED_BYTE']);
             gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
             gl.enable(gl.DEPTH_TEST);
         }


### PR DESCRIPTION
use `layer.options['terrainTileMode']` to turn on.

This mode will return flat tiles (including loaded tiles and missed tiles) in current view instead of cascaded tiles with parent tiles and child tiles.