### PR TITLE
Update UIComponent.js to set offet

### DIFF
--- a/src/ui/UIComponent.js
+++ b/src/ui/UIComponent.js
@@ -835,7 +835,7 @@ class UIComponent extends Eventable(Class) {
             if (this.options['rotateWithMap'] && bearing) {
                 r += ` rotateZ(${Math.round(-bearing)}deg)`;
             }
-            return 'translate3d(' + p.x + 'px,' + p.y + 'px, 0px)' + r;
+            return 'translate3d(' + Math.fround(p.x) + 'px,' + Math.fround(p.y) + 'px, 0px)' + r;
         } else {
             return 'translate(' + p.x + 'px,' + p.y + 'px)';
         }


### PR DESCRIPTION
translate3d 在 小数位时会出现样式计算错误，比如：
border-image
border-image-slice
border-image-width
translate3d 为整数时没有问题，小数时会出现边框断裂，出现空白线条