### PR TITLE
TileLayer support only load tiles in mask

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
   "dependencies": {
     "@maptalks/feature-filter": "^1.3.0",
     "@maptalks/function-type": "^1.3.1",
+    "@maptalks/geojson-bbox": "^1.0.5",
     "frustum-intersects": "^0.1.0",
+    "lineclip": "^1.1.5",
     "rbush": "^2.0.2",
     "simplify-js": "^1.2.1"
   },
@@ -63,7 +65,6 @@
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/node": "^20.11.30",
     "@types/offscreencanvas": "^2019.7.3",
-    "rollup-plugin-dts": "^6.1.0",
     "eslint": "^8.57.0",
     "eslint-plugin-mocha": "^10.4.1",
     "expect-maptalks": "^0.4.1",
@@ -80,6 +81,7 @@
     "karma-sinon": "^1.0.5",
     "mocha": "^10.3.0",
     "rollup": "^4.13.0",
+    "rollup-plugin-dts": "^6.1.0",
     "sinon": "^3.2.1",
     "tslib": "^2.6.2",
     "typedoc": "^0.25.13",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "@maptalks/feature-filter": "^1.3.0",
     "@maptalks/function-type": "^1.3.1",
-    "@maptalks/geojson-bbox": "^1.0.5",
     "frustum-intersects": "^0.1.0",
     "lineclip": "^1.1.5",
     "rbush": "^2.0.2",

--- a/src/core/util/bbox.ts
+++ b/src/core/util/bbox.ts
@@ -1,5 +1,4 @@
 import Coordinate from '../../geo/Coordinate';
-import GeoJSONBBOX from '@maptalks/geojson-bbox';
 import lineclip from 'lineclip';
 
 const minx = Infinity, miny = Infinity, maxx = -Infinity, maxy = -Infinity;
@@ -114,9 +113,12 @@ export function bboxIntersect(bbox1: BBOX, bbox2: BBOX) {
  * @returns 
  */
 export function bboxInMask(bbox: BBOX, maskGeoJSON: Record<string, any>): boolean {
-    //cal geojson bbox
-    maskGeoJSON.bbox = maskGeoJSON.bbox || GeoJSONBBOX(maskGeoJSON);
+    //geojson bbox
     const maskBBOX = maskGeoJSON.bbox;
+    if (!maskBBOX) {
+        console.error('maskGeoJSON bbox is null:', maskGeoJSON);
+        return false;
+    }
     if (!bboxIntersect(maskBBOX, bbox)) {
         return false;
     } else {

--- a/src/core/util/bbox.ts
+++ b/src/core/util/bbox.ts
@@ -127,7 +127,8 @@ export function bboxInMask(bbox: BBOX, maskGeoJSON: Record<string, any>): boolea
             console.error('maskGeoJSON is error,not find geometry.', maskGeoJSON);
             return false;
         }
-        let { type, coordinates } = geometry;
+        let { coordinates } = geometry;
+        const type = geometry.type;
         if (type === 'Polygon') {
             coordinates = [coordinates];
         }

--- a/src/core/util/bbox.ts
+++ b/src/core/util/bbox.ts
@@ -87,3 +87,19 @@ export function bufferBBOX(bbox: BBOX, bufferSize = 0) {
     bbox[2] += bufferSize;
     bbox[3] += bufferSize;
 }
+
+export function bboxIntersect(bbox1: BBOX, bbox2: BBOX) {
+    if (bbox1[2] < bbox2[0]) {
+        return false;
+    }
+    if (bbox1[1] > bbox2[3]) {
+        return false;
+    }
+    if (bbox1[0] > bbox2[2]) {
+        return false;
+    }
+    if (bbox1[3] < bbox2[1]) {
+        return false;
+    }
+    return true;
+}

--- a/src/layer/Layer.ts
+++ b/src/layer/Layer.ts
@@ -557,6 +557,7 @@ class Layer extends JSONAble(Eventable(Renderable(Class))) {
             try {
                 this._maskGeoJSON = mask.toGeoJSON();
             } catch (error) {
+                delete this._maskGeoJSON;
                 console.error(error);
             }
         }

--- a/src/layer/tile/TileLayer.ts
+++ b/src/layer/tile/TileLayer.ts
@@ -1524,6 +1524,13 @@ class TileLayer extends Layer {
         if (type.indexOf('Polygon') === -1) {
             return true;
         }
+        if (!maskGeoJSON.bbox) {
+            const extent = mask.getExtent();
+            if (!extent) {
+                return true;
+            }
+            maskGeoJSON.bbox = [extent.xmin, extent.ymin, extent.xmax, extent.ymax];
+        }
         const tileBBOX = this._getTileBBox(tile);
         if (!tileBBOX) {
             return true;

--- a/src/layer/tile/TileLayer.ts
+++ b/src/layer/tile/TileLayer.ts
@@ -95,8 +95,7 @@ class TileHashset {
  * @property              [options.fetchOptions=object]       - fetch params,such as fetchOptions: { 'headers': { 'accept': '' } }, about accept value more info https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values
  * @property             [options.awareOfTerrain=true]       - if the tile layer is aware of terrain.
  * @property             [options.bufferPixel=0.5]       - tile buffer size,the unit is pixel
- * @property             [options.depthMask=true]       - mask to decide whether to write depth buffer
- * @property             [options.onlyLoadTilesInMask=false]       - only load tiles in mask
+ * @property             [options.depthMask=true]       - mask to decide whether to write depth buffe
  * @memberOf TileLayer
  * @instance
  */
@@ -162,7 +161,6 @@ const options: TileLayerOptionsType = {
     'mipmapTexture': true,
     'depthMask': true,
     'currentTilesFirst': true,
-    'onlyLoadTilesInMask': false,
     'forceRenderOnMoving': true
 };
 
@@ -274,7 +272,7 @@ class TileLayer extends Layer {
         } else {
             result = this._getCascadeTiles(z, parentLayer);
         }
-        if (!this.options.onlyLoadTilesInMask) {
+        if (!this._maskGeoJSON) {
             return result;
         }
         const tileGrids: Array<TileGridType> = result.tileGrids || [];
@@ -1646,5 +1644,4 @@ export type TileLayerOptionsType = LayerOptionsType & {
     tileStackDepth?: number;
     mipmapTexture?: boolean;
     currentTilesFirst?: boolean;
-    onlyLoadTilesInMask?: boolean;
 };

--- a/src/layer/tile/TileLayer.ts
+++ b/src/layer/tile/TileLayer.ts
@@ -1557,10 +1557,9 @@ class TileLayer extends Layer {
                         maxx = Math.max(x, maxx);
                         maxy = Math.max(y, maxy);
                     }
-                    if (minx === maxx || miny === maxy) {
-                        return false;
+                    if (minx !== maxx && miny !== maxy) {
+                        return true;
                     }
-                    return true;
                 }
             }
             return false;

--- a/src/layer/tile/TileLayer.ts
+++ b/src/layer/tile/TileLayer.ts
@@ -1385,8 +1385,8 @@ class TileLayer extends Layer {
         }
         return this._tileConfig || this._defaultTileConfig;
     }
-
-    _bindMap() {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _bindMap(args?: any) {
         this._onSpatialReferenceChange();
         // eslint-disable-next-line prefer-rest-params
         return super._bindMap.apply(this, arguments);

--- a/src/layer/tile/TileLayer.ts
+++ b/src/layer/tile/TileLayer.ts
@@ -1549,6 +1549,17 @@ class TileLayer extends Layer {
                 const outRing = rings[0];
                 const result = lineclip.polygon(outRing, tileBBOX);
                 if (result.length > 0) {
+                    let minx = Infinity, maxx = -Infinity, miny = Infinity, maxy = -Infinity;
+                    for (let j = 0, len1 = result.length; j < len1; j++) {
+                        const [x, y] = result[j];
+                        minx = Math.min(x, minx);
+                        miny = Math.min(y, miny);
+                        maxx = Math.max(x, maxx);
+                        maxy = Math.max(y, maxy);
+                    }
+                    if (minx === maxx || miny === maxy) {
+                        return false;
+                    }
                     return true;
                 }
             }

--- a/src/layer/tile/TileLayer.ts
+++ b/src/layer/tile/TileLayer.ts
@@ -1488,24 +1488,18 @@ class TileLayer extends Layer {
         if (!map) {
             return;
         }
-        const z = tile.z;
-        const x = tile.x;
-        const y = tile.y;
-        const res = tile.res || map._getResolution(z);
-        const tileConfig = this._getTileConfig();
-        if (!tileConfig) {
+
+        const extent2d = tile.extent2d;
+        if (!extent2d) {
             return;
         }
-        const prjExtent = tileConfig.getTilePrjExtent(x, y, res);
-        if (!prjExtent) {
-            return;
-        }
-        const { xmin, ymin, xmax, ymax } = prjExtent;
+        const res = tile.res;
+
+        const { xmin, ymin, xmax, ymax } = extent2d;
         const pmin = new Point(xmin, ymin),
             pmax = new Point(xmax, ymax);
-        const projection = map.getProjection();
-        const min = projection.unproject(pmin),
-            max = projection.unproject(pmax);
+        const min = map.pointAtResToCoordinate(pmin, res, TEMP_POINT0),
+            max = map.pointAtResToCoordinate(pmax, res, TEMP_POINT1);
         return [min.x, min.y, max.x, max.y];
 
     }

--- a/src/map/Map.ts
+++ b/src/map/Map.ts
@@ -157,6 +157,7 @@ const options: MapOptionsType = {
     'switchDragButton': false,
     'mousemoveThrottleTime': MOUSEMOVE_THROTTLE_TIME,
     'maxFPS': 0,
+    'cameraInfiniteFar': false,
     'debug': false
 };
 

--- a/src/renderer/layer/CanvasRenderer.ts
+++ b/src/renderer/layer/CanvasRenderer.ts
@@ -571,7 +571,8 @@ class CanvasRenderer extends Class {
             return null;
         }
         const maskExtent2D = this._maskExtent = mask._getMaskPainter().get2DExtent();
-        if (!maskExtent2D.intersects(this._extent2D)) {
+        //fix vt _extent2D is null
+        if (maskExtent2D && this._extent2D && !maskExtent2D.intersects(this._extent2D)) {
             this.layer.fire('renderstart', {
                 'context': this.context,
                 'gl': this.gl
@@ -597,6 +598,9 @@ class CanvasRenderer extends Class {
     clipCanvas(context: CanvasRenderingContext2D & { isMultiClip: boolean, isClip: boolean }) {
         const mask = this.layer.getMask();
         if (!mask) {
+            return false;
+        }
+        if (!this.layer.options.maskClip) {
             return false;
         }
         const old = this.middleWest;


### PR DESCRIPTION
fix #2332
- support TileLayer 256
- support TileLayer 512
- support PRESET-VT(512)

```js
 const layer = new maptalks.TileLayer('base', {
            debug: true,
            // repeatWorld: false,
            // cascadeTiles:false,
            urlTemplate: "https://webst01.is.autonavi.com/appmaptile?style=6&x={x}&y={y}&z={z}",
            urlTemplate: 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
            subdomains: ["a", "b", "c", "d"],
            maxAvailableZoom: 18,
            maskClip: false,
        });
   const polygons = maptalks.GeoJSON.toGeometry(geojson);
            layer.setMask(polygons[0]);
            layer.addTo(map);


```