### PR TITLE
Update UIComponent.ts, _toCSSTranslate, add Math.fround

### DIFF
--- a/src/ui/UIComponent.ts
+++ b/src/ui/UIComponent.ts
@@ -877,7 +877,7 @@ class UIComponent extends Eventable(Class) {
             }
             return 'translate3d(' + Math.fround(p.x) + 'px,' + Math.fround(p.y) + 'px, 0px)' + r;
         } else {
-            return 'translate(' + p.x + 'px,' + p.y + 'px)';
+            return 'translate(' + Math.fround(p.x) + 'px,' + Math.fround(p.y) + 'px)';
         }
     }
 


### PR DESCRIPTION
transform: translate3d(700.372px, 418.574px, 0px) scale(1);  此属性在chrome 下会导致 infoWindow 模糊和其他样式问题