### PR TITLE
drawAltitude support Array<Symbol> for every Geometry

### DIFF
--- a/src/renderer/geometry/symbolizers/DrawAltitudeSymbolizer.ts
+++ b/src/renderer/geometry/symbolizers/DrawAltitudeSymbolizer.ts
@@ -129,7 +129,15 @@ export default class DrawAltitudeSymbolizer extends PointSymbolizer {
 
     _getStyle(): any {
         // read drawAltitude from layer every time
-        let style = this.geometry.getLayer().options['drawAltitude'];
+        const layer = this.geometry.getLayer();
+        let style = layer.options['drawAltitude'];
+        if (Array.isArray(style)) {
+            const geos = layer.getGeometries() || [];
+            const index = geos.indexOf(this.geometry);
+            if (index >= 0) {
+                style = style[index] || defaultSymbol;
+            }
+        }
         if (!isObject(style)) {
             style = defaultSymbol;
         }


### PR DESCRIPTION
fix #1376 

```js

    var map = new maptalks.Map("map", {
            center: [120.132398, 30.18717],
            zoom: 14,
            pitch: 56,
            bearing: 60,
            baseLayer: new maptalks.TileLayer("base", {
                urlTemplate:
                    "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
                subdomains: ["a", "b", "c", "d"],
            }),
        });
        var line = new maptalks.LineString(
            [
                [120.132398, 30.18717],
                [120.13316, 30.187342],
            ],
            {
                symbol: {
                    lineColor: "#FF69B4",
                    lineWidth: 3,
                },
                properties: {
                    altitude: [100, 400],
                },
            }
        );
        var line1 = new maptalks.LineString(
            [
                [120.13316, 30.187342],
                [120.13434, 30.187646],
            ],
            {
                symbol: {
                    lineColor: "#1bbc9b",
                    lineWidth: 3,
                },
                properties: {
                    altitude: [400, 500],
                },
            }
        );
        var line2 = new maptalks.LineString(
            [
                [120.13434, 30.187646],
                [120.135492, 30.18796],
            ],
            {
                symbol: {
                    lineColor: "#8B008B",
                    lineWidth: 3,
                },
                properties: {
                    altitude: [500, 600],
                },
            }
        );
        var layer = new maptalks.VectorLayer("vector", [line, line1, line2], {
            enableAltitude: true,
            drawAltitude: [
                {
                    polygonFill: 'red',
                    polygonOpacity: 0.3,
                    lineWidth: 0,
                },
                {
                    polygonFill: 'green',
                    polygonOpacity: 0.3,
                    lineWidth: 0,
                },
                {
                    polygonFill: 'blue',
                    polygonOpacity: 0.3,
                    lineWidth: 0,
                },
            ]
        });
        layer.addTo(map);
```