### PR TITLE
Geometry edit fire handledremove event when control vertext remove

### DIFF
--- a/src/geometry/editor/GeometryEditor.ts
+++ b/src/geometry/editor/GeometryEditor.ts
@@ -989,7 +989,7 @@ class GeometryEditor extends Eventable(Class) {
             me._updating = false;
 
             /**
-             * changed geometry shape event, fired when edit control vertext  remove
+             * changed geometry shape event, fired when edit control vertex  remove
              *
              * @event Geometry#handledremove
              * @type {Object}

--- a/src/geometry/editor/GeometryEditor.ts
+++ b/src/geometry/editor/GeometryEditor.ts
@@ -991,12 +991,12 @@ class GeometryEditor extends Eventable(Class) {
             /**
              * changed geometry shape event, fired when edit control vertex  remove
              *
-             * @event Geometry#handledremove
+             * @event Geometry#handleremove
              * @type {Object}
-             * @property {String} type - handledremove
+             * @property {String} type - handleremove
              * @property {Geometry} target - the geometry fires the event
              */
-            me._geometry.fire('handledremove', Object.assign({}, param, { coordinate: map.containerPointToCoordinate(param.containerPoint), vertex: param.target }));
+            me._geometry.fire('handleremove', Object.assign({}, param, { coordinate: map.containerPointToCoordinate(param.containerPoint), vertex: param.target }));
         }
 
         function moveVertexHandle(handleConatainerPoint: any, index: number, ringIndex: number = 0): void {

--- a/src/geometry/editor/GeometryEditor.ts
+++ b/src/geometry/editor/GeometryEditor.ts
@@ -987,6 +987,16 @@ class GeometryEditor extends Eventable(Class) {
             }
             onVertexAddOrRemove();
             me._updating = false;
+
+            /**
+             * changed geometry shape event, fired when edit control vertext  remove
+             *
+             * @event Geometry#handledremove
+             * @type {Object}
+             * @property {String} type - handledremove
+             * @property {Geometry} target - the geometry fires the event
+             */
+            me._geometry.fire('handledremove', Object.assign({}, param, { coordinate: map.containerPointToCoordinate(param.containerPoint), vertex: param.target }));
         }
 
         function moveVertexHandle(handleConatainerPoint: any, index: number, ringIndex: number = 0): void {


### PR DESCRIPTION
```js
  const layer1 = new maptalks.VectorLayer('layer1', {
            zIndex: 1
        }).addTo(map);

        const coordinates = [

            [116.949462890625, 34.849875031954156]

            , [116.949462890625, 34.858890491257824]

            , [116.949462890625, 34.858890491257824]

            , [116.949462890625, 34.849875031954156]
        ];

        const line = new maptalks.LineString(coordinates, {
            symbol: {
                lineColor: 'red'
            }
        }).addTo(layer1);


        line.startEdit();

        line.on('handleremove', e => {
            console.log(e);
        })

```