### PR TITLE
improve idle message loop

### DIFF
--- a/src/GlobalConfig.ts
+++ b/src/GlobalConfig.ts
@@ -8,19 +8,14 @@ const GlobalConfig = {
     //test env
     isTest: false,
 
-    idleEnable: true,
     //idle logging
     idleLog: false,
-    //idle 时间阈值
-    idleTimeRemaining: 4,
     //idle 申请不到idle时,强制执行时间阈值
-    idleForceTimeThreshold: 100,
-    //idle 超时阈值
-    idleTimeout: 1000,
+    idleForceTimeThreshold: 48,
     //worker 数量
     workerCount: (getGlobalThis().MAPTALKS_WORKER_COUNT) as number || 0,
     //每个Worker Message中封装的task message数量
-    taskCountPerWorkerMessage: 5,
+    messagePostRatioPerWorker: 0.3,
     //当前运行环境的最大FPS,用户可以手动配置，否则将自动检测并赋值,为地图锁帧渲染准备
     maxFPS: 0
 };

--- a/src/core/worker/Worker.ts
+++ b/src/core/worker/Worker.ts
@@ -51,7 +51,7 @@ const header = `
         func(workerExports,self);
         adapters[key]=workerExports;
         workerExports.initialize && workerExports.initialize(self);
-        
+
     }
     onmessage = function (msg) {
         msg = msg.data;
@@ -65,8 +65,8 @@ const header = `
         }
         // postMessage when main thread idle
         if(msg.messageType==='idle'){
-            var messageCount = msg.messageCount||5;
-            handleMessageQueue(messageCount);
+            var messageRatio = msg.messageRatio;
+            handleMessageQueue(messageRatio);
             return;
         }
         if (msg.messageType === 'batch') {
@@ -98,16 +98,17 @@ const header = `
     }
 
     var messageResultQueue = [];
-    
-    function handleMessageQueue(messageCount){
+
+    function handleMessageQueue(messageRatio){
        if(messageResultQueue.length===0){
           return;
        }
-       var queues = messageResultQueue.slice(0,messageCount);
+       var count = Math.ceil((messageRatio || 1) * messageResultQueue.length);
+       var queues = messageResultQueue.slice(0, count);
        queues.forEach(function(queue){
           post(queue.callback,queue.err,queue.data,queue.buffers);
        });
-       messageResultQueue=messageResultQueue.slice(messageCount,Infinity);
+       messageResultQueue=messageResultQueue.slice(count, Infinity);
     }
 
     function post(callback, err, data, buffers) {

--- a/src/core/worker/WorkerPool.ts
+++ b/src/core/worker/WorkerPool.ts
@@ -120,10 +120,10 @@ export default class WorkerPool {
         return this.workers || [];
     }
 
-    broadcastIdleMessage() {
+    broadcastIdleMessage(messageRatio: number) {
         const workers = this.getWorkers();
         workers.forEach(worker => {
-            worker.postMessage({ messageType: 'idle', messageCount: GlobalConfig.taskCountPerWorkerMessage });
+            worker.postMessage({ messageType: 'idle', messageRatio });
         });
         return this;
     }


### PR DESCRIPTION
总体思路是放宽idle message的调用门槛，让worker message分散到更长的时间周期里返回给主线程，同时不会因为主线程忙而长时间堵塞worker消息的返回。

主要改进如下：
* 改为按百分比设置worker向主线程返回的消息数量，解决繁忙时，worker中消息排队过久的问题
* busyLoop（animFrameLoop）返回更少消息：目前固定为idleLoop中返回比例的一半
* 实测发现workerPool.commit()对性能影响很小，broadcastIdleMessage改为每次loop都会执行。