### PR TITLE
Optimizing the experience of maxExtent through boundary constraints

### DIFF
--- a/src/core/util/bbox.ts
+++ b/src/core/util/bbox.ts
@@ -105,6 +105,11 @@ export function bboxIntersect(bbox1: BBOX, bbox2: BBOX) {
     return true;
 }
 
+export function bboxInBBOX(bbox1: BBOX, bbox2: BBOX) {
+    const [x1, y1, x2, y2] = bbox1;
+    return x1 >= bbox2[0] && x2 <= bbox2[2] && y1 >= bbox2[1] && y2 <= bbox2[3];
+}
+
 /**
  * bbox Intersect Mask
  * apply on TileLayer,VectorTileLayer,Geo3DTileLayer Layers

--- a/src/map/Map.ViewHistory.ts
+++ b/src/map/Map.ViewHistory.ts
@@ -3,7 +3,7 @@ import Map, { MapAnimationOptionsType, MapViewType } from './Map';
 
 declare module "./Map" {
     interface Map {
-
+        _viewHistory: Array<MapViewType>;
         zoomToPreviousView(options?: any): MapViewType;
         hasPreviousView(): boolean;
         zoomToNextView(options?: any): MapViewType;

--- a/src/map/Map.Zoom.ts
+++ b/src/map/Map.Zoom.ts
@@ -154,7 +154,7 @@ Map.include(/** @lends Map.prototype */{
           * @property {Number} to                      - zoom level zooming to
           */
         this._fireEvent('zoomend', { 'from': startZoomVal, 'to': nextZoom });
-        if (!this._verifyExtent(this._getPrjCenter())) {
+        if (!this._verifyExtent(this._getPrjCenter()) && !this.options.limitExtentOnMaxExtent) {
             this._panTo(this._prjMaxExtent.getCenter());
         }
     },

--- a/src/map/Map.ts
+++ b/src/map/Map.ts
@@ -1777,7 +1777,7 @@ export class Map extends Handlerable(Eventable(Renderable(Class))) {
          * @property {Event} domEvent                 - dom event
          */
         this._fireEvent('moveend', (param && param['domEvent']) ? this._parseEvent(param['domEvent'], 'moveend') : param);
-        this._limitMaxExtent();
+
         if (!this._verifyExtent(this._getPrjCenter()) && this._originCenter) {
             const moveTo = this._originCenter;
             this._panTo(moveTo);
@@ -2235,63 +2235,47 @@ export class Map extends Handlerable(Eventable(Renderable(Class))) {
         let forceCenterX: number, forceCenterY: number;
         if (leftOverflow) {
             // console.log('need ←');
-            const c1 = this._containerPointToPrj(new Point(0, height / 2));
-            const xoffset = maxExtentBBOX[0] - mapBBOX[0];
-            const c2 = this._containerPointToPrj(new Point(xoffset, height / 2));
-            translateX = c2.x - c1.x;
+            translateX = maxExtentBBOX[0] - mapBBOX[0]
         }
         if (rightOverflow && translateX === 0) {
             // console.log('need →');
-            const c1 = this._containerPointToPrj(new Point(width, height / 2));
-            const xoffset = maxExtentBBOX[2] - mapBBOX[2];
-            const c2 = this._containerPointToPrj(new Point(width + xoffset, height / 2));
-            translateX = c2.x - c1.x;
+            translateX = maxExtentBBOX[2] - mapBBOX[2]
         }
         if (leftOverflow && rightOverflow) {
             //强制重置center.x为maxtent.center.x
-            forceCenterX = maxPrjExtent.getCenter().x;
+            forceCenterX = maxExtent.getCenter().x;
         }
 
         if (topOverflow) {
             // console.log('need ↑');
-            const c1 = this._containerPointToPrj(new Point(width / 2, 0));
-            const yoffset = maxExtentBBOX[1] - mapBBOX[1];
-            const c2 = this._containerPointToPrj(new Point(width / 2, yoffset));
-            translateY = c2.y - c1.y;
+            translateY = maxExtentBBOX[1] - mapBBOX[1]
         }
         if (bottomOverflow && translateY === 0) {
             // console.log('need ↓');
-            const c1 = this._containerPointToPrj(new Point(width / 2, height));
-            const yoffset = maxExtentBBOX[3] - mapBBOX[3];
-            const c2 = this._containerPointToPrj(new Point(width / 2, height + yoffset));
-            translateY = c2.y - c1.y;
+            translateY = maxExtentBBOX[3] - mapBBOX[3]
         }
 
         if (topOverflow && bottomOverflow) {
             //强制重置center.y为maxtent.center.y
-            forceCenterY = maxPrjExtent.getCenter().y;
+            forceCenterY = maxExtent.getCenter().y;
         }
 
         if (forceMaxExtentCenter) {
             this._limitMaxExtenting = true;
             this.setCenter(forceMaxExtentCenter);
         } else if (translateX !== 0 || translateY !== 0 || isNumber(forceCenterX) || isNumber(forceCenterY)) {
-            const prjCenter = this._getPrjCenter().copy();
+            const point = new Point(width / 2 + translateX, height / 2 + translateY);
+            const center = this.containerPointToCoord(point);
             if (isNumber(forceCenterX)) {
-                prjCenter.x = forceCenterX;
-            } else {
-                prjCenter.x += translateX;
+                center.x = forceCenterX;
             }
             if (isNumber(forceCenterY)) {
-                prjCenter.y = forceCenterY;
-            } else {
-                prjCenter.y += translateY;
+                center.y = forceCenterY;
             }
             this._limitMaxExtenting = true;
-            this._setPrjCenter(prjCenter);
+            this.setCenter(center);
         }
         this._limitMaxExtenting = false;
-
         return this;
     }
 

--- a/src/map/Map.ts
+++ b/src/map/Map.ts
@@ -2263,7 +2263,7 @@ export class Map extends Handlerable(Eventable(Renderable(Class))) {
             translateY = offsetbottom = abs(height - bottom);
         }
 
-        //同时溢出去最小的值
+        //同时溢出取最小的值,四周最近距离吸附
         if (offsetleft !== 0 && offsetright !== 0) {
             translateX = offsetleft;
             if (abs(offsetright) < abs(offsetleft)) {

--- a/src/map/Map.ts
+++ b/src/map/Map.ts
@@ -137,6 +137,7 @@ const options: MapOptionsType = {
     'maxZoom': null,
     'minZoom': null,
     'maxExtent': null,
+    'limitExtentOnMaxExtent': false,
     'fixCenterOnResize': true,
 
     'checkSize': true,
@@ -2197,7 +2198,7 @@ export class Map extends Handlerable(Eventable(Renderable(Class))) {
     }
 
     _limitMaxExtent() {
-        if (this._limitMaxExtenting) {
+        if (this._limitMaxExtenting || !this.options.limitExtentOnMaxExtent) {
             return this;
         }
         const maxPrjExtent = this._prjMaxExtent;
@@ -2222,47 +2223,40 @@ export class Map extends Handlerable(Eventable(Renderable(Class))) {
 
         let translateX = 0, translateY = 0;
         //x轴方向
-        const xDirection = () => {
-            //left
-            if (mapBBOX[0] < maxExtentBBOX[0]) {
-                // console.log('←');
-                const c1 = this.containerPointToCoord(new Point(0, height / 2));
-                const xoffset = maxExtentBBOX[0] - mapBBOX[0];
-                const c2 = this.containerPointToCoord(new Point(xoffset, height / 2));
-                translateX = c2.x - c1.x;
-            }
-            //right
-            if (mapBBOX[2] > maxExtentBBOX[2]) {
-                // console.log('→');
-                const c1 = this.containerPointToCoord(new Point(width, height / 2));
-                const xoffset = maxExtentBBOX[2] - mapBBOX[2];
-                const c2 = this.containerPointToCoord(new Point(width + xoffset, height / 2));
-                translateX = c2.x - c1.x;
-            }
+        //left
+        if (mapBBOX[0] < maxExtentBBOX[0]) {
+            // console.log('←');
+            const c1 = this.containerPointToCoord(new Point(0, height / 2));
+            const xoffset = maxExtentBBOX[0] - mapBBOX[0];
+            const c2 = this.containerPointToCoord(new Point(xoffset, height / 2));
+            translateX = c2.x - c1.x;
+        }
+        //right
+        if (mapBBOX[2] > maxExtentBBOX[2]) {
+            // console.log('→');
+            const c1 = this.containerPointToCoord(new Point(width, height / 2));
+            const xoffset = maxExtentBBOX[2] - mapBBOX[2];
+            const c2 = this.containerPointToCoord(new Point(width + xoffset, height / 2));
+            translateX = c2.x - c1.x;
         }
 
         //y轴方向
-        const yDirection = () => {
-            //up
-            if (mapBBOX[1] < maxExtentBBOX[1]) {
-                // console.log('↑');
-                const c1 = this.containerPointToCoord(new Point(width / 2, 0));
-                const yoffset = maxExtentBBOX[1] - mapBBOX[1];
-                const c2 = this.containerPointToCoord(new Point(width / 2, yoffset));
-                translateY = c2.y - c1.y;
-
-            }
-            //down
-            if (mapBBOX[3] > maxExtentBBOX[3]) {
-                // console.log('↓');
-                const c1 = this.containerPointToCoord(new Point(width / 2, height));
-                const yoffset = maxExtentBBOX[3] - mapBBOX[3];
-                const c2 = this.containerPointToCoord(new Point(width / 2, height + yoffset));
-                translateY = c2.y - c1.y;
-            }
+        //up
+        if (mapBBOX[1] < maxExtentBBOX[1]) {
+            // console.log('↑');
+            const c1 = this.containerPointToCoord(new Point(width / 2, 0));
+            const yoffset = maxExtentBBOX[1] - mapBBOX[1];
+            const c2 = this.containerPointToCoord(new Point(width / 2, yoffset));
+            translateY = c2.y - c1.y;
         }
-        xDirection();
-        yDirection();
+        //down
+        if (mapBBOX[3] > maxExtentBBOX[3]) {
+            // console.log('↓');
+            const c1 = this.containerPointToCoord(new Point(width / 2, height));
+            const yoffset = maxExtentBBOX[3] - mapBBOX[3];
+            const c2 = this.containerPointToCoord(new Point(width / 2, height + yoffset));
+            translateY = c2.y - c1.y;
+        }
         if (translateX !== 0 || translateY !== 0) {
             this._limitMaxExtenting = true;
             currentView.center[0] += translateX;
@@ -2663,6 +2657,7 @@ export type MapOptionsType = {
     maxZoom?: number;
     minZoom?: number;
     maxExtent?: Extent;
+    limitExtentOnMaxExtent?: boolean;
     fixCenterOnResize?: boolean;
     checkSize?: boolean;
     checkSizeInterval?: number;

--- a/src/map/Map.ts
+++ b/src/map/Map.ts
@@ -1782,6 +1782,7 @@ export class Map extends Handlerable(Eventable(Renderable(Class))) {
             const moveTo = this._originCenter;
             this._panTo(moveTo);
         }
+        this._limitMaxExtent();
     }
 
     onDragRotateStart(param) {

--- a/src/map/Map.ts
+++ b/src/map/Map.ts
@@ -2232,8 +2232,7 @@ export class Map extends Handlerable(Eventable(Renderable(Class))) {
         const rightOverflow = mapBBOX[2] > maxExtentBBOX[2];
         const topOverflow = mapBBOX[1] < maxExtentBBOX[1];
         const bottomOverflow = mapBBOX[3] > maxExtentBBOX[3];
-        const center = this.getCenter().copy();
-        let forceCenter: Coordinate;
+        let forceCenterX: number, forceCenterY: number;
         if (leftOverflow) {
             // console.log('need ←');
             const c1 = this._containerPointToPrj(new Point(0, height / 2));
@@ -2250,8 +2249,7 @@ export class Map extends Handlerable(Eventable(Renderable(Class))) {
         }
         if (leftOverflow && rightOverflow) {
             //强制重置center.x为maxtent.center.x
-            forceCenter = forceCenter || center;
-            forceCenter.x = maxExtent.getCenter().x;
+            forceCenterX = maxPrjExtent.getCenter().x;
         }
 
         if (topOverflow) {
@@ -2271,17 +2269,24 @@ export class Map extends Handlerable(Eventable(Renderable(Class))) {
 
         if (topOverflow && bottomOverflow) {
             //强制重置center.y为maxtent.center.y
-            forceCenter = forceCenter || center;
-            forceCenter.y = maxExtent.getCenter().y;
+            forceCenterY = maxPrjExtent.getCenter().y;
         }
 
-        if (forceMaxExtentCenter || forceCenter) {
+        if (forceMaxExtentCenter) {
             this._limitMaxExtenting = true;
-            this.setCenter(forceMaxExtentCenter || forceCenter);
-        } else if (translateX !== 0 || translateY !== 0) {
+            this.setCenter(forceMaxExtentCenter);
+        } else if (translateX !== 0 || translateY !== 0 || isNumber(forceCenterX) || isNumber(forceCenterY)) {
             const prjCenter = this._getPrjCenter().copy();
-            prjCenter.x += translateX;
-            prjCenter.y += translateY;
+            if (isNumber(forceCenterX)) {
+                prjCenter.x = forceCenterX;
+            } else {
+                prjCenter.x += translateX;
+            }
+            if (isNumber(forceCenterY)) {
+                prjCenter.y = forceCenterY;
+            } else {
+                prjCenter.y += translateY;
+            }
             this._limitMaxExtenting = true;
             this._setPrjCenter(prjCenter);
         }


### PR DESCRIPTION
fix #667 
fix #1602 
fix #2236 
fix #2317 

```js
   var map = new maptalks.Map('map', {
            center: [120, 31.498568],
            zoom: 12,
            limitExtentOnMaxExtent: true,
            // baseLayer: new maptalks.TileLayer('base', {
            //     urlTemplate: "https://webst01.is.autonavi.com/appmaptile?style=6&x={x}&y={y}&z={z}",
            //     subdomains: ['a', 'b', 'c', 'd'],
            //     attribution: '&copy; <a href="http://osm.org">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/">CARTO</a>'
            // })
        });

        const baseLayer = new maptalks.TileLayer('base', {
            urlTemplate: "https://webst01.is.autonavi.com/appmaptile?style=6&x={x}&y={y}&z={z}",
            subdomains: ['a', 'b', 'c', 'd'],
            attribution: '&copy; <a href="http://osm.org">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/">CARTO</a>'
        }).addTo(map);

        const bbox = [118.681640625, 30.929531859423406, 121.318359375, 32.06416211965538];
        map.setMaxExtent(bbox);

        const layer = new maptalks.VectorLayer('layer').addTo(map);

        const line = new maptalks.LineString(map.getMaxExtent().toArray()).addTo(layer);

        const polygon = new maptalks.Polygon([map.getMaxExtent().toArray()]);
        baseLayer.setMask(polygon);


```