### PR TITLE
disable deconstruction and assignment

### DIFF
--- a/src/core/Class.ts
+++ b/src/core/Class.ts
@@ -223,7 +223,8 @@ class Class {
      */
     static addInitHook(fn: Function | string, ...args) {
         const init: Function = typeof fn === 'function' ? fn : function () {
-            this[fn].call(this, ...args);
+            // eslint-disable-next-line prefer-spread
+            this[fn].apply(this, args);
         };
         const proto = this.prototype;
         const parentProto = Object.getPrototypeOf(proto);

--- a/src/core/CollisionIndex.ts
+++ b/src/core/CollisionIndex.ts
@@ -32,7 +32,11 @@ class CollisionIndex {
      * @returns {Boolean}
      */
     collides(box) {
-        [search.minX, search.minY, search.maxX, search.maxY] = box;
+        // [search.minX, search.minY, search.maxX, search.maxY] = box;
+        search.minX = box[0];
+        search.minY = box[1];
+        search.maxX = box[2];
+        search.maxY = box[3];
         return this._tree.collides(search);
     }
 

--- a/src/core/Eventable.ts
+++ b/src/core/Eventable.ts
@@ -127,7 +127,8 @@ export default function <T extends MixinConstructor>(Base: T) {
          * @param context        - the context of the handler
          */
         addEventListener(...args): this {
-            return this.on.call(this, ...args);
+            // eslint-disable-next-line prefer-spread
+            return this.on.apply(this, args);
         }
 
         /**
@@ -228,7 +229,8 @@ export default function <T extends MixinConstructor>(Base: T) {
          * @param context          - the context of the handler
          */
         removeEventListener(...args) {
-            return this.off.call(this, ...args);
+            // eslint-disable-next-line prefer-spread
+            return this.off.apply(this, args);
         }
 
         /**
@@ -322,9 +324,9 @@ export default function <T extends MixinConstructor>(Base: T) {
                 delete fn[key];
                 called = true;
                 if (context) {
-                    handler.call(context, ...args);
+                    handler.apply(context, args);
                 } else {
-                    handler.call(this, ...args);
+                    handler.apply(this, args);
                 }
                 (onceHandler as any)._called = true;
                 // me.off(evtType, onceHandler, this);

--- a/src/core/util/bbox.ts
+++ b/src/core/util/bbox.ts
@@ -106,7 +106,8 @@ export function bboxIntersect(bbox1: BBOX, bbox2: BBOX) {
 }
 
 export function bboxInBBOX(bbox1: BBOX, bbox2: BBOX) {
-    const [x1, y1, x2, y2] = bbox1;
+    // const [x1, y1, x2, y2] = bbox1;
+    const x1 = bbox1[0], y1 = bbox1[1], x2 = bbox1[2], y2 = bbox1[3];
     return x1 >= bbox2[0] && x2 <= bbox2[2] && y1 >= bbox2[1] && y2 <= bbox2[3];
 }
 
@@ -144,7 +145,8 @@ export function bboxInMask(bbox: BBOX, maskGeoJSON: Record<string, any>): boolea
             if (result.length > 0) {
                 let minx = Infinity, maxx = -Infinity, miny = Infinity, maxy = -Infinity;
                 for (let j = 0, len1 = result.length; j < len1; j++) {
-                    const [x, y] = result[j];
+                    // const [x, y] = result[j];
+                    const x = result[j][0], y = result[j][1];
                     minx = Math.min(x, minx);
                     miny = Math.min(y, miny);
                     maxx = Math.max(x, maxx);

--- a/src/core/util/marker.ts
+++ b/src/core/util/marker.ts
@@ -108,7 +108,12 @@ export function getMarkerRotationExtent(out: PointExtent, rad: number, width: nu
     minx += rx;
     miny += ry;
     //计算旋转图形后新的图形的BBOX
-    const [offsetX, offsetY, w, h] = getImageRotateBBOX(width, height, rad);
+    const bbox = getImageRotateBBOX(width, height, rad);
+    const offsetX = bbox[0];
+    const offsetY = bbox[1];
+    const w = bbox[2];
+    const h = bbox[3];
+    // const [offsetX, offsetY, w, h] = getImageRotateBBOX(width, height, rad);
     minx += offsetX;
     miny += offsetY;
     const maxx = minx + Math.max(width, w), maxy = miny + Math.max(height, h);
@@ -213,7 +218,7 @@ function rotateExtent(fixedExtent: PointExtent, angle: number) {
     return ROTATE_EXTENT.convertTo(p => p._rotate(angle), fixedExtent);
 }
 
-export function getMarkerRotation(symbol:any, prop = 'markerRotation') {
+export function getMarkerRotation(symbol: any, prop = 'markerRotation') {
     const r = symbol[prop];
     if (!isNumber(r)) {
         return 0;

--- a/src/core/util/strings.ts
+++ b/src/core/util/strings.ts
@@ -190,7 +190,8 @@ export function replaceVariable(str: string, props: Object) {
         }
         return value;
     }
-    const [left, right] = TEMPLATE_CHARS;
+    // const [left, right] = TEMPLATE_CHARS;
+    const left = TEMPLATE_CHARS[0], right = TEMPLATE_CHARS[1];
     const keys = templateKeys(str);
     for (let i = 0, len = keys.length; i < len; i++) {
         const key = keys[i];
@@ -202,7 +203,7 @@ export function replaceVariable(str: string, props: Object) {
 
 function templateKeys(str) {
     str += EMPTY_STRING;
-    const [left, right] = TEMPLATE_CHARS;
+    const left = TEMPLATE_CHARS[0], right = TEMPLATE_CHARS[1];
     const keys = [];
     let start = false;
     let key = EMPTY_STRING;

--- a/src/geo/Point.ts
+++ b/src/geo/Point.ts
@@ -87,8 +87,9 @@ class Point extends Position {
 
     _perp() {
         // [this.x, this.y] = [-this.y, this.x]
+        const x = this.x;
         this.x = -this.y;
-        this.y = this.x;
+        this.y = x;
         return this;
     }
 

--- a/src/geo/Point.ts
+++ b/src/geo/Point.ts
@@ -86,7 +86,6 @@ class Point extends Position {
     }
 
     _perp() {
-        // [this.x, this.y] = [-this.y, this.x]
         const x = this.x;
         this.x = -this.y;
         this.y = x;

--- a/src/geo/Point.ts
+++ b/src/geo/Point.ts
@@ -86,7 +86,9 @@ class Point extends Position {
     }
 
     _perp() {
-        [this.x, this.y] = [-this.y, this.x]
+        // [this.x, this.y] = [-this.y, this.x]
+        this.x = -this.y;
+        this.y = this.x;
         return this;
     }
 

--- a/src/geometry/Geometry.ts
+++ b/src/geometry/Geometry.ts
@@ -1272,7 +1272,11 @@ export class Geometry extends JSONAble(Eventable(Handlerable(Class))) {
             const bbox = getDefaultBBOX();
             //cal all points center
             pointsBBOX(coord, bbox);
-            const [minx, miny, maxx, maxy] = bbox;
+            // const [minx, miny, maxx, maxy] = bbox;
+            const minx = bbox[0];
+            const miny = bbox[1];
+            const maxx = bbox[2];
+            const maxy = bbox[3];
             cx = (minx + maxx) / 2;
             cy = (miny + maxy) / 2;
         }
@@ -1928,9 +1932,9 @@ export class Geometry extends JSONAble(Eventable(Handlerable(Class))) {
     _genMinMaxAlt(): void {
         if (this._minAlt === undefined || this._maxAlt === undefined) {
             const altitude = this._getAltitude();
-            const [min, max] = getMinMaxAltitude(altitude);
-            this._minAlt = min;
-            this._maxAlt = max;
+            const minmax = getMinMaxAltitude(altitude);
+            this._minAlt = minmax[0];
+            this._maxAlt = minmax[1];
         }
     }
 

--- a/src/geometry/MultiPath.ts
+++ b/src/geometry/MultiPath.ts
@@ -22,7 +22,9 @@ class MultiPath extends MultiGeometry {
      */
     getCenterInExtent(extent: Extent): null | Coordinate {
         const children = this.getGeometries();
-        let [sumx, sumy, counter] = [0, 0, 0];
+        let sumx = 0,
+            sumy = 0,
+            counter = 0;
         children.forEach(l => {
             // @ts-expect-error todo
             const c = l.getCenterInExtent(extent);

--- a/src/geometry/Path.ts
+++ b/src/geometry/Path.ts
@@ -421,7 +421,8 @@ export class Path extends Geometry {
         }
         const rings = [shell];
         if (this.hasHoles && this.hasHoles()) {
-            rings.push.call(rings, ...this.getHoles());
+            // eslint-disable-next-line prefer-spread
+            rings.push.apply(rings, this.getHoles());
         }
         return this._coords2Extent(rings, this._getProjection());
     }
@@ -430,7 +431,8 @@ export class Path extends Geometry {
     _computePrjExtent(_?: any): Extent {
         const coords = [this._getPrjCoordinates()];
         if (this.hasHoles && this.hasHoles()) {
-            coords.push.call(coords, ...this._getPrjHoles());
+            // eslint-disable-next-line prefer-spread
+            coords.push.apply(coords, this._getPrjHoles());
         }
         return this._coords2Extent(coords);
     }

--- a/src/geometry/Path.ts
+++ b/src/geometry/Path.ts
@@ -256,7 +256,8 @@ export class Path extends Geometry {
         if (clipped.length === 0) {
             return null;
         }
-        let [sumx, sumy, counter] = [0, 0, 0];
+        // let [sumx, sumy, counter] = [0, 0, 0];
+        let sumx = 0, sumy = 0, counter = 0;
         clipped.forEach(part => {
             if (Array.isArray(part)) {
                 part.forEach(c => {

--- a/src/geometry/Sector.ts
+++ b/src/geometry/Sector.ts
@@ -125,7 +125,9 @@ export class Sector extends Circle {
     //@internal
     _getShell(): RingCoordinates {
 
-        const [startAngle, endAngle] = this._correctAngles();
+        const angles = this._correctAngles();
+        const startAngle = angles[0], endAngle = angles[1];
+        // const [startAngle, endAngle] = this._correctAngles();
 
         const measurer = this._getMeasurer(),
             center = this.getCoordinates(),
@@ -183,7 +185,9 @@ export class Sector extends Circle {
             // [0.0, 360.0)
             angle = atan2 < 0 ? (atan2 + 2 * Math.PI) * 360 / (2 * Math.PI) :
                 atan2 * 360 / (2 * Math.PI);
-        const [startAngle, endAngle] = this._correctAngles();
+        // const [startAngle, endAngle] = this._correctAngles();
+        const angles = this._correctAngles();
+        const startAngle = angles[0], endAngle = angles[1];
         const sAngle = startAngle % 360,
             eAngle = endAngle % 360;
         let between = false;
@@ -200,7 +204,8 @@ export class Sector extends Circle {
         if (isNil(this._radius)) {
             return 0;
         }
-        const [startAngle, endAngle] = this._correctAngles();
+        const angles = this._correctAngles();
+        const startAngle = angles[0], endAngle = angles[1];
         return Math.PI * 2 * this._radius * Math.abs(startAngle - endAngle) / 360 + 2 * this._radius;
     }
 
@@ -209,7 +214,8 @@ export class Sector extends Circle {
         if (isNil(this._radius)) {
             return 0;
         }
-        const [startAngle, endAngle] = this._correctAngles();
+        const angles = this._correctAngles();
+        const startAngle = angles[0], endAngle = angles[1];
         return Math.PI * Math.pow(this._radius, 2) * Math.abs(startAngle - endAngle) / 360;
     }
 

--- a/src/geometry/editor/GeometryEditor.ts
+++ b/src/geometry/editor/GeometryEditor.ts
@@ -1,5 +1,5 @@
 import { INTERNAL_LAYER_PREFIX } from '../../core/Constants';
-import { isNil, isNumber, sign, removeFromArray, UID, isFunction } from '../../core/util';
+import { isNil, isNumber, sign, removeFromArray, UID, isFunction, extend } from '../../core/util';
 import { lowerSymbolOpacity } from '../../core/util/style';
 import Class from '../../core/Class';
 import Eventable from '../../core/Eventable';
@@ -1015,7 +1015,7 @@ class GeometryEditor extends Eventable(Class) {
              * @property {String} type - handleremove
              * @property {Geometry} target - the geometry fires the event
              */
-            me._geometry.fire('handleremove', Object.assign({}, param, { coordinate: map.containerPointToCoordinate(param.containerPoint), vertex: param.target }));
+            me._geometry.fire('handleremove', extend({}, param, { coordinate: map.containerPointToCoordinate(param.containerPoint), vertex: param.target }));
         }
 
         function moveVertexHandle(handleConatainerPoint: any, index: number, ringIndex: number = 0): void {
@@ -1384,15 +1384,19 @@ class GeometryEditor extends Eventable(Class) {
             record[0].forEach(o => {
                 const m = o[0],
                     args = o.slice(1);
-                geoToEdit[m].call(geoToEdit, ...args);
+                // eslint-disable-next-line prefer-spread
+                geoToEdit[m].apply(geoToEdit, args);
                 if (geoToEdit !== geo) {
-                    geo[m].call(geo, ...args);
+                    // eslint-disable-next-line prefer-spread
+                    geo[m].apply(geo, args);
                 }
             });
         } else {
-            geoToEdit[record[0]].call(geoToEdit, ...record[1]);
+            // eslint-disable-next-line prefer-spread
+            geoToEdit[record[0]].apply(geoToEdit, record[1]);
             if (geoToEdit !== geo) {
-                geo[record[0]].call(geo, ...record[1]);
+                // eslint-disable-next-line prefer-spread
+                geo[record[0]].apply(geo, record[1]);
             }
         }
         this._updating = updating;

--- a/src/layer/Layer.ts
+++ b/src/layer/Layer.ts
@@ -1,5 +1,5 @@
 import Class from '../core/Class';
-import { isFunction, isNil, isNumber } from '../core/util';
+import { extend, isFunction, isNil, isNumber } from '../core/util';
 import Eventable from '../core/Eventable';
 import JSONAble from '../core/JSONAble';
 import Renderable from '../renderer/Renderable';
@@ -867,7 +867,7 @@ Layer.prototype.fire = function (eventType: string, param) {
         * @property {Layer} target    - the layer fires the event
         * @property {Boolean} visible        - value of visible
        */
-        this.fire('visiblechange', Object.assign({}, param, { visible: this.options.visible }));
+        this.fire('visiblechange', extend({}, param, { visible: this.options.visible }));
     }
     return this;
 };

--- a/src/layer/tile/TileLayer.ts
+++ b/src/layer/tile/TileLayer.ts
@@ -728,7 +728,8 @@ class TileLayer extends Layer {
         const renderer = this.getRenderer();
         let { xmin, ymin, xmax, ymax } = node.extent2d;
         if (node.offset && !isFunction(this.options.offset)) {
-            const [x, y] = node.offset;
+            const xyoffset = node.offset;
+            const x = xyoffset[0], y = xyoffset[1];
             xmin += x;
             xmax += x;
             ymin += y;

--- a/src/layer/tile/TileLayer.ts
+++ b/src/layer/tile/TileLayer.ts
@@ -10,7 +10,8 @@ import {
     isString,
     extend,
     Vector3,
-    Matrix4
+    Matrix4,
+    pushIn
 } from '../../core/util';
 import LRUCache, { ArrayLRUCache } from '../../core/util/LRUCache';
 import Browser from '../../core/Browser';
@@ -495,7 +496,9 @@ class TileLayer extends Layer {
                     this._disablePyramid = true;
                     return this.getTiles(z, layer);
                 }
-                queue = [...rootNodes.tiles];
+                // queue = [...rootNodes.tiles];
+                queue = [];
+                pushIn(queue, rootNodes.tiles);
             }
         } else {
             const rootNodes = this._getRootNodes(offset0);
@@ -504,7 +507,9 @@ class TileLayer extends Layer {
                 this._disablePyramid = true;
                 return this.getTiles(z, layer);
             }
-            queue = [...rootNodes.tiles];
+            // queue = [...rootNodes.tiles];
+            queue = [];
+            pushIn(queue, rootNodes.tiles);
         }
         const glRes = map.getGLRes();
         const offsets = {
@@ -618,13 +623,15 @@ class TileLayer extends Layer {
         }
         if (z === maxZoom) {
             if (hasCurrentIn) {
-                queue.push(...children);
+                // queue.push(...children);
+                pushIn(queue, children);
             } else {
                 tiles.push(node);
                 gridExtent._combine(node.extent2d);
             }
         } else {
-            queue.push(...children);
+            // queue.push(...children);
+            pushIn(queue, children);
         }
 
     }
@@ -1350,7 +1357,7 @@ class TileLayer extends Layer {
         // offset result can't be cached, as it varies with map's center.
         let offset = this.options['offset'];
         if (isFunction(offset)) {
-            offset = offset.call(this, ...params);
+            offset = offset.apply(this, params);
         }
         if (isNumber(offset)) {
             offset = [offset, offset];

--- a/src/map/Map.CoordTransform.ts
+++ b/src/map/Map.CoordTransform.ts
@@ -494,8 +494,10 @@ Map.include(/** @lends Map.prototype */{
             const min2d = extent2D.getMin(),
                 max2d = extent2D.getMax();
             const fullExtent = this.getFullExtent();
-            const [minx, maxx] = (!fullExtent || fullExtent.left <= fullExtent.right) ? [min2d.x, max2d.x] : [max2d.x, min2d.x];
-            const [miny, maxy] = (!fullExtent || fullExtent.top > fullExtent.bottom) ? [max2d.y, min2d.y] : [min2d.y, max2d.y];
+            const minmaxx = (!fullExtent || fullExtent.left <= fullExtent.right) ? [min2d.x, max2d.x] : [max2d.x, min2d.x];
+            const minmaxy = (!fullExtent || fullExtent.top > fullExtent.bottom) ? [max2d.y, min2d.y] : [min2d.y, max2d.y];
+            const minx = minmaxx[0], maxx = minmaxx[1];
+            const miny = minmaxy[0], maxy = minmaxy[1];
             const min = min2d.set(minx, maxy);
             const max = max2d.set(maxx, miny);
             return new Extent(

--- a/src/map/Map.ts
+++ b/src/map/Map.ts
@@ -1885,7 +1885,11 @@ export class Map extends Handlerable(Eventable(Renderable(Class))) {
         const screenBottomBoundary = height + viewportPadding;
         let { xmin, ymin, xmax, ymax } = (box as PointExtent);
         if (Array.isArray(box)) {
-            [xmin, ymin, xmax, ymax] = box;
+            // [xmin, ymin, xmax, ymax] = box;
+            xmin = box[0];
+            ymin = box[1];
+            xmax = box[2];
+            ymax = box[3];
         }
         return xmax < viewportPadding || xmin >= screenRightBoundary || ymax < viewportPadding || ymin > screenBottomBoundary;
     }
@@ -2289,7 +2293,11 @@ export class Map extends Handlerable(Eventable(Renderable(Class))) {
 
         let offsetleft = 0, offsetright = 0, offsettop = 0, offsetbottom = 0;
         const abs = Math.abs;
-        const [left, top, right, bottom] = maxExtentBBOX;
+        // const [left, top, right, bottom] = maxExtentBBOX;
+        const left = maxExtentBBOX[0];
+        const top = maxExtentBBOX[1];
+        const right = maxExtentBBOX[2];
+        const bottom = maxExtentBBOX[3];
 
         //left overflow
         if (left > 0 && right > width) {

--- a/src/map/Map.ts
+++ b/src/map/Map.ts
@@ -353,7 +353,8 @@ export class Map extends Handlerable(Eventable(Renderable(Class))) {
     static addOnLoadHook(fn: string | ((...args) => void), ...args) { // (Function) || (String, args...)
         // const args = Array.prototype.slice.call(arguments, 1);
         const onload = typeof fn === 'function' ? fn : function () {
-            this[fn].call(this, ...args);
+            // eslint-disable-next-line prefer-spread
+            this[fn].apply(this, args);
         };
         this.prototype._onLoadHooks = this.prototype._onLoadHooks || [];
         this.prototype._onLoadHooks.push(onload);

--- a/src/map/spatial-reference/SpatialReference.WMTS.ts
+++ b/src/map/spatial-reference/SpatialReference.WMTS.ts
@@ -26,7 +26,8 @@ function getProjection(projection) {
 
 function strReplace(str, repArray = []) {
     repArray.forEach(rep => {
-        const [template, value] = rep;
+        // const [template, value] = rep;
+        const template = rep[0], value = rep[1];
         str = str.replace(template, value);
     });
     return str;

--- a/src/renderer/geometry/Painter.ts
+++ b/src/renderer/geometry/Painter.ts
@@ -669,7 +669,7 @@ class Painter extends Class {
             if (ctx.shadowBlur || this.symbolizers[i].symbol['shadowBlur']) {
                 this._prepareShadow(ctx, this.symbolizers[i].symbol);
             }
-            this.symbolizers[i].symbolize(...contexts);
+            this.symbolizers[i].symbolize(contexts[0], contexts[1]);
         }
         this._afterPaint();
         this._painted = true;
@@ -707,7 +707,7 @@ class Painter extends Class {
                     ]
                 };
                 this._prepareShadow(ctx, this.symbolizers[i].symbol);
-                this.symbolizers[i].symbolize(...contexts);
+                this.symbolizers[i].symbolize(contexts[0], contexts[1]);
             }
             if (bak) {
                 this._renderPoints = bak;

--- a/src/renderer/geometry/Painter.ts
+++ b/src/renderer/geometry/Painter.ts
@@ -485,12 +485,12 @@ class Painter extends Class {
         let _2DExtent, glExtent, pitch;
         if (mapStateCache) {
             //@internal
-        _2DExtent = mapStateCache._2DExtent;
+            _2DExtent = mapStateCache._2DExtent;
             glExtent = mapStateCache.glExtent;
             pitch = mapStateCache.pitch;
         } else {
             //@internal
-        _2DExtent = map.get2DExtent();
+            _2DExtent = map.get2DExtent();
             glExtent = map.get2DExtentAtRes(map.getGLRes());
             pitch = map.getPitch();
         }
@@ -989,7 +989,9 @@ class Painter extends Class {
         }
         const altitude = this.geometry._getAltitude();
         this._propAlt = altitude;
-        const [min, max] = getMinMaxAltitude(altitude);
+        const minmax = getMinMaxAltitude(altitude);
+        const min = minmax[0], max = minmax[1];
+        // const [min, max] = getMinMaxAltitude(altitude);
         this.minAltitude = min;
         this.maxAltitude = max;
         if (!altitude) {

--- a/src/renderer/geometry/VectorRenderer.ts
+++ b/src/renderer/geometry/VectorRenderer.ts
@@ -72,7 +72,11 @@ function _computeRotatedPrjExtent() {
     const bbox = getDefaultBBOX();
     //cal all points center
     pointsBBOX(coord, bbox);
-    const [minx, miny, maxx, maxy] = bbox;
+    // const [minx, miny, maxx, maxy] = bbox;
+    const minx = bbox[0];
+    const miny = bbox[1];
+    const maxx = bbox[2];
+    const maxy = bbox[3];
     return new Extent(minx, miny, maxx, maxy);
 }
 
@@ -199,7 +203,9 @@ const sectorInclude = {
         const map = this.getMap();
         const pt = map._prjToPointAtRes(this._getPrjCoordinates(), map.getGLRes());
         const size = this._getRenderSize(pt);
-        const [startAngle, endAngle] = this._correctAngles();
+        // const [startAngle, endAngle] = this._correctAngles();
+        const angles = this._correctAngles();
+        const startAngle = angles[0], endAngle = angles[1];
         return [
             pt,
             size[0],

--- a/src/renderer/geometry/VectorRenderer.ts
+++ b/src/renderer/geometry/VectorRenderer.ts
@@ -127,17 +127,19 @@ const el = {
         const pcenter = this._getPrjCoordinates();
         const pt: Point = map._prjToPointAtRes(pcenter, map.getGLRes());
         const size = this._getRenderSize(pt);
-        return [pt, ...size];
+        const result = [pt];
+        pushIn(result, size);
+        return result;
     },
 
     //@internal
     _paintOn: function (...args: any[]) {
         if (this._paintAsPath()) {
-            // @ts-expect-error
-            return Canvas.polygon(...args);
+            // eslint-disable-next-line prefer-spread
+            return Canvas.polygon.apply(Canvas, args);
         } else {
-            // @ts-expect-error
-            return Canvas.ellipse(...args);
+            // eslint-disable-next-line prefer-spread
+            return Canvas.ellipse.apply(Canvas, args);
         }
     },
 
@@ -216,8 +218,8 @@ const sectorInclude = {
     //@internal
     _paintOn: function (...args: any[]) {
         if (this._paintAsPath()) {
-            // @ts-expect-error
-            return Canvas.polygon(...args);
+            // eslint-disable-next-line prefer-spread
+            return Canvas.polygon.apply(Canvas, args);
         } else {
             const r = this.getMap().getBearing();
             if (r) {
@@ -225,8 +227,8 @@ const sectorInclude = {
                 args[3][0] += r;
                 args[3][1] += r;
             }
-            // @ts-expect-error
-            return Canvas.sector(...args);
+            // eslint-disable-next-line prefer-spread
+            return Canvas.sector.apply(Canvas, args);
         }
     }
 };

--- a/src/renderer/geometry/symbolizers/StrokeAndFillSymbolizer.ts
+++ b/src/renderer/geometry/symbolizers/StrokeAndFillSymbolizer.ts
@@ -189,14 +189,16 @@ export default class StrokeAndFillSymbolizer extends CanvasSymbolizer {
         if (!Array.isArray(points) || !points.length) {
             return;
         }
-        const [p1, p2] = getGradientPoints(points);
+        const pts = getGradientPoints(points);
+        const p1 = pts[0], p2 = pts[1];
         if (!p1 || !p2) {
             console.error('unable create canvas LinearGradient,error data:', points);
             return;
         }
         const grad = ctx.createLinearGradient(p1.x, p1.y, p2.x, p2.y);
         lineColor['colorStops'].forEach(function (stop: [number, string]) {
-            grad.addColorStop(...stop);
+            const step = stop[0], color = stop[1];
+            grad.addColorStop(step, color);
         });
         ctx.strokeStyle = grad;
     }

--- a/src/renderer/geometry/symbolizers/StrokeAndFillSymbolizer.ts
+++ b/src/renderer/geometry/symbolizers/StrokeAndFillSymbolizer.ts
@@ -1,3 +1,4 @@
+import { pushIn } from 'maptalks/dist/core/util';
 import { ResourceCache } from '../..';
 import { getValueOrDefault } from '../../../core/util';
 import { isGradient as checkGradient } from '../../../core/util/style';
@@ -83,11 +84,13 @@ export default class StrokeAndFillSymbolizer extends CanvasSymbolizer {
                 }
                 const params = [ctx, points[i]];
                 if (paintParams.length > 1) {
-                    params.push(...paintParams.slice(1));
+                    // params.push(...paintParams.slice(1));
+                    pushIn(params, paintParams.slice(1));
                 }
                 params.push(style['lineOpacity'], style['polygonOpacity'], style['lineDasharray']);
                 // @ts-expect-error todo 属性“_paintOn”在类型“Geometry”上不存在
-                const bbox = this.geometry._paintOn(...params);
+                // eslint-disable-next-line prefer-spread
+                const bbox = this.geometry._paintOn.apply(this.geometry, params);
                 this._setBBOX(ctx, bbox);
                 this._bufferBBOX(ctx, tolerance);
             }
@@ -97,10 +100,12 @@ export default class StrokeAndFillSymbolizer extends CanvasSymbolizer {
                 this._createGradient(ctx, points, style['lineColor']);
             }
             const params = [ctx];
-            params.push(...paintParams);
+            // params.push(...paintParams);
+            pushIn(params, paintParams);
             params.push(style['lineOpacity'], style['polygonOpacity'], style['lineDasharray']);
             // @ts-expect-error todo 属性“_paintOn”在类型“Geometry”上不存在
-            const bbox = this.geometry._paintOn(...params);
+            // eslint-disable-next-line prefer-spread
+            const bbox = this.geometry._paintOn.apply(this.geometry, params);
             this._setBBOX(ctx, bbox);
             this._bufferBBOX(ctx, tolerance);
         }

--- a/src/renderer/geometry/symbolizers/StrokeAndFillSymbolizer.ts
+++ b/src/renderer/geometry/symbolizers/StrokeAndFillSymbolizer.ts
@@ -1,6 +1,5 @@
-import { pushIn } from 'maptalks/dist/core/util';
 import { ResourceCache } from '../..';
-import { getValueOrDefault } from '../../../core/util';
+import { getValueOrDefault, pushIn } from '../../../core/util';
 import { isGradient as checkGradient } from '../../../core/util/style';
 import Coordinate from '../../../geo/Coordinate';
 import PointExtent from '../../../geo/PointExtent';

--- a/src/renderer/geometry/symbolizers/VectorMarkerSymbolizer.ts
+++ b/src/renderer/geometry/symbolizers/VectorMarkerSymbolizer.ts
@@ -77,7 +77,8 @@ export default class VectorMarkerSymbolizer extends PointSymbolizer {
         for (let i = cookedPoints.length - 1; i >= 0; i--) {
             let point = cookedPoints[i];
             const size = calVectorMarkerSize(MARKER_SIZE, this.style);
-            const [width, height] = size;
+            // const [width, height] = size;
+            const width = size[0], height = size[1];
             // const origin = this._rotate(ctx, point, this._getRotationAt(i));
             let extent: PointExtent;
             const origin = this.getRotation() ? this._rotate(ctx, point, this._getRotationAt(i)) : null;

--- a/src/renderer/layer/CanvasRenderer.ts
+++ b/src/renderer/layer/CanvasRenderer.ts
@@ -144,10 +144,10 @@ class CanvasRenderer extends Class {
                     }
                 });
             } else {
-                drawFn.call(this, ...args);
+                drawFn.apply(this, args);
             }
         } else {
-            drawFn.call(this, ...args);
+            drawFn.apply(this, args);
         }
     }
 

--- a/src/renderer/layer/canvaslayer/CanvasLayerRenderer.ts
+++ b/src/renderer/layer/canvaslayer/CanvasLayerRenderer.ts
@@ -5,7 +5,7 @@ import CanvasRenderer from '../../../renderer/layer/CanvasRenderer';
 export default class CanvasLayerRenderer extends CanvasRenderer {
     buffer: HTMLCanvasElement;
     //@internal
-    _drawContext: any[];df
+    _drawContext: any[];
     //@internal
     _predrawed: boolean;
     //@internal

--- a/src/renderer/layer/canvaslayer/CanvasLayerRenderer.ts
+++ b/src/renderer/layer/canvaslayer/CanvasLayerRenderer.ts
@@ -133,11 +133,14 @@ export default class CanvasLayerRenderer extends CanvasRenderer {
         }
         const args: any[] = [this.context, view];
         const params = ensureParams(this.getDrawParams());
-        return [
-            ...args,
-            ...params,
-            ...this._drawContext
-        ];
+        const result = [];
+        pushIn(result, args, params, this._drawContext);
+        return result;
+        // return [
+        //     ...args,
+        //     ...params,
+        //     ...this._drawContext
+        // ];
     }
 
     //@internal

--- a/src/renderer/layer/canvaslayer/CanvasLayerRenderer.ts
+++ b/src/renderer/layer/canvaslayer/CanvasLayerRenderer.ts
@@ -1,11 +1,11 @@
-import { pushIn } from 'maptalks/dist/core/util';
 import Canvas from '../../../core/Canvas';
+import { pushIn } from '../../../core/util';
 import CanvasRenderer from '../../../renderer/layer/CanvasRenderer';
 
 export default class CanvasLayerRenderer extends CanvasRenderer {
     buffer: HTMLCanvasElement;
     //@internal
-    _drawContext: any[];
+    _drawContext: any[];df
     //@internal
     _predrawed: boolean;
     //@internal

--- a/src/renderer/layer/canvaslayer/CanvasLayerRenderer.ts
+++ b/src/renderer/layer/canvaslayer/CanvasLayerRenderer.ts
@@ -1,3 +1,4 @@
+import { pushIn } from 'maptalks/dist/core/util';
 import Canvas from '../../../core/Canvas';
 import CanvasRenderer from '../../../renderer/layer/CanvasRenderer';
 
@@ -38,11 +39,13 @@ export default class CanvasLayerRenderer extends CanvasRenderer {
     draw(...args: any[]) {
         this.prepareCanvas();
         this.prepareDrawContext();
-        this._drawLayer(...args);
+        // eslint-disable-next-line prefer-spread
+        this._drawLayer.apply(this, args);
     }
 
     drawOnInteracting(...args: any[]) {
-        this._drawLayerOnInteracting(...args);
+        // eslint-disable-next-line prefer-spread
+        this._drawLayerOnInteracting.apply(this, args);
     }
 
     getCanvasImage() {
@@ -130,11 +133,14 @@ export default class CanvasLayerRenderer extends CanvasRenderer {
         }
         const args: any[] = [this.context, view];
         const params = ensureParams(this.getDrawParams());
-        return [
-            ...args,
-            ...params,
-            ...this._drawContext
-        ];
+        const result = [];
+        pushIn(result, args, params, this._drawContext);
+        return result;
+        // return [
+        //     ...args,
+        //     ...params,
+        //     ...this._drawContext
+        // ];
     }
 
     //@internal
@@ -157,7 +163,8 @@ export default class CanvasLayerRenderer extends CanvasRenderer {
         if (!params) {
             return;
         }
-        this.layer.drawOnInteracting(...params, ...args);
+        pushIn(params, args);
+        this.layer.drawOnInteracting.apply(this, params);
         this.completeRender();
     }
 }

--- a/src/renderer/layer/canvaslayer/CanvasLayerRenderer.ts
+++ b/src/renderer/layer/canvaslayer/CanvasLayerRenderer.ts
@@ -133,14 +133,11 @@ export default class CanvasLayerRenderer extends CanvasRenderer {
         }
         const args: any[] = [this.context, view];
         const params = ensureParams(this.getDrawParams());
-        const result = [];
-        pushIn(result, args, params, this._drawContext);
-        return result;
-        // return [
-        //     ...args,
-        //     ...params,
-        //     ...this._drawContext
-        // ];
+        return [
+            ...args,
+            ...params,
+            ...this._drawContext
+        ];
     }
 
     //@internal

--- a/src/renderer/layer/vectorlayer/OverlayLayerCanvasRenderer.ts
+++ b/src/renderer/layer/vectorlayer/OverlayLayerCanvasRenderer.ts
@@ -64,7 +64,8 @@ class OverlayLayerRenderer extends CanvasRenderer {
             }
             if (!this.resources) {
                 // @tip 解构会有一定的性能影响，对于少量数据是否可以忽略
-                resources.push(...res);
+                // resources.push(...res);
+                pushIn(resources, res);
             } else {
                 for (let i = 0; i < res.length; i++) {
                     const url = res[i][0];

--- a/src/renderer/map/MapCanvasRenderer.ts
+++ b/src/renderer/map/MapCanvasRenderer.ts
@@ -815,7 +815,8 @@ class MapCanvasRenderer extends MapRenderer {
         const clipped = renderer.clipCanvas(this.context as any);
         if (matrix) {
             ctx.save();
-            ctx.setTransform(...(matrix as any));
+            // eslint-disable-next-line prefer-spread
+            ctx.setTransform.apply(ctx, matrix);
         }
 
         /*let outlineColor = layer.options['debugOutline'];


### PR DESCRIPTION
fix #2397 

why?

mtk的的编译是 es5,使用高级语法回导致tsc里进行tslib polyfill，导致性能下降

下面是tslib polyfill的 解构和赋值的polyfill 函数
```js
 function __read(o, n) {
      var m = typeof Symbol === "function" && o[Symbol.iterator];
      if (!m) return o;
      var i = m.call(o), r, ar = [], e;
      try {
          while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
      }
      catch (error) { e = { error: error }; }
      finally {
          try {
              if (r && !r.done && (m = i["return"])) m.call(i);
          }
          finally { if (e) throw e.error; }
      }
      return ar;
  }

```