### PR TITLE
animateTo support reverse Rotation direction

### DIFF
--- a/src/map/Map.Anim.ts
+++ b/src/map/Map.Anim.ts
@@ -103,7 +103,7 @@ Map.include(/** @lends Map.prototype */{
             step = options;
             options = {};
         }
-        if ((options as any).reverse) {
+        if ((options as any).counterclockwise) {
             reverseBearing(view, this);
         }
         if (needValidateView(view, this)) {
@@ -269,7 +269,7 @@ Map.include(/** @lends Map.prototype */{
         // function in van Wijk (2003).
         view = extend({}, this.getView(), view);
         view.bearing = view.bearing % 360;
-        if ((options as any).reverse) {
+        if ((options as any).counterclockwise) {
             reverseBearing(view, this);
         }
         if (needValidateView(view, this)) {

--- a/src/map/Map.Anim.ts
+++ b/src/map/Map.Anim.ts
@@ -1,7 +1,7 @@
 import { Animation, Player } from '../core/Animation';
 import Coordinate from '../geo/Coordinate';
 import Point from '../geo/Point';
-import Map from './Map';
+import { Map, MapViewType } from './Map';
 import { isNil, isFunction, hasOwn, extend, clamp } from '../core/util';
 
 
@@ -36,6 +36,40 @@ declare module "./Map" {
 //     return true;
 // }
 
+function needValidateView(view: MapViewType, map: Map) {
+    const bearing = view.bearing;
+    const currentBearing = map.getBearing();
+    //当bearing溢出半角时,且线型变化时不经过0时,例如：[currentBearing=170,bearing=220],[currentBearing=-170,bearing=-220]
+    if (currentBearing >= 0 && bearing > 180) {
+        return false;
+    }
+    if (currentBearing <= 0 && bearing < -180) {
+        return false;
+    }
+    return true;
+}
+//反向旋转,bearing的变化正常为 [a,b],开启reverse后变化就反向了,例如 [170,-170] reverse后为 [170,190]
+function reverseBearing(view: MapViewType, map: Map) {
+    const bearing = view.bearing;
+    const currentBearing = map.getBearing();
+    //such as  [170,-170]
+    if (currentBearing >= 0 && bearing < 0) {
+        view.bearing = 180 + (180 - Math.abs(bearing));
+    }
+    //such as  [-170,170]
+    if (currentBearing <= 0 && bearing > 0) {
+        view.bearing = -180 - (180 - Math.abs(bearing));
+    }
+
+    if (currentBearing >= 0 && bearing > 0) {
+        view.bearing = -180 - (180 - Math.abs(bearing));
+    }
+
+    if (currentBearing <= 0 && bearing < 0) {
+        view.bearing = 180 + (180 - Math.abs(bearing));
+    }
+}
+
 Map.include(/** @lends Map.prototype */{
 
     /**
@@ -63,11 +97,17 @@ Map.include(/** @lends Map.prototype */{
      */
     animateTo(view, options = {}, step) {
         view = extend({}, this.getView(), view);
-        this._validateView(view);
+        view.bearing = view.bearing % 360;
         // this._stopAnim(this._animPlayer);
         if (isFunction(options)) {
             step = options;
             options = {};
+        }
+        if ((options as any).reverse) {
+            reverseBearing(view, this);
+        }
+        if (needValidateView(view, this)) {
+            this._validateView(view);
         }
         const projection = this.getProjection(),
             currView = this.getView(),
@@ -228,7 +268,13 @@ Map.include(/** @lends Map.prototype */{
         // Where applicable, local variable documentation begins with the associated variable or
         // function in van Wijk (2003).
         view = extend({}, this.getView(), view);
-        this._validateView(view);
+        view.bearing = view.bearing % 360;
+        if ((options as any).reverse) {
+            reverseBearing(view, this);
+        }
+        if (needValidateView(view, this)) {
+            this._validateView(view);
+        }
 
         if (this._animPlayer) {
             if (this._isInternalAnimation) {

--- a/src/map/Map.Camera.ts
+++ b/src/map/Map.Camera.ts
@@ -347,8 +347,8 @@ Map.include(/** @lends Map.prototype */{
      */
     setCameraOrientation(params) {
         const { position } = params;
-        let { pitch, bearing } = params;
         this._validateView(params);
+        let { pitch, bearing } = params;
         pitch = pitch || 0;
         bearing = bearing || 0;
         const { zoom, cameraToGroundDistance } = this.getFitZoomForCamera(position, pitch);

--- a/src/map/Map.ts
+++ b/src/map/Map.ts
@@ -2839,7 +2839,7 @@ export type MapDataURLType = {
     save?: boolean;
 }
 
-export type MapAnimationOptionsType = AnimationOptionsType & { reverse?: boolean }
+export type MapAnimationOptionsType = AnimationOptionsType & { counterclockwise?: boolean }
 
 export type MapIdentifyOptionsType = {
     tolerance?: number;

--- a/src/map/Map.ts
+++ b/src/map/Map.ts
@@ -1043,8 +1043,21 @@ export class Map extends Handlerable(Eventable(Renderable(Class))) {
             return;
         }
         if (isNumber(view.bearing)) {
-            view.bearing = Math.max(-180, view.bearing);
-            view.bearing = Math.min(180, view.bearing);
+            let bearing = view.bearing;
+            //周期性
+            bearing = bearing % 360;
+            //自动转换为负的值
+            if (bearing > 180) {
+                bearing = -180 + Math.abs(bearing - 180);
+            }
+            //自动转换为正的值
+            if (bearing < -180) {
+                bearing = 180 - Math.abs(bearing + 180);
+            }
+            view.bearing = bearing;
+
+            // view.bearing = Math.max(-180, view.bearing);
+            // view.bearing = Math.min(180, view.bearing);
         }
         if (isNumber(view.pitch)) {
             view.pitch = Math.max(0, view.pitch);
@@ -2826,7 +2839,7 @@ export type MapDataURLType = {
     save?: boolean;
 }
 
-export type MapAnimationOptionsType = AnimationOptionsType;
+export type MapAnimationOptionsType = AnimationOptionsType & { reverse?: boolean }
 
 export type MapIdentifyOptionsType = {
     tolerance?: number;

--- a/test/map/MapAnimSpec.js
+++ b/test/map/MapAnimSpec.js
@@ -10,13 +10,13 @@ describe('Map.Anim', function () {
         container.style.height = '2px';
         document.body.appendChild(container);
         var option = {
-            zoomAnimation:false,
+            zoomAnimation: false,
             zoom: 17,
             center: center,
-            baseLayer : new maptalks.TileLayer('tile', {
-                urlTemplate : TILE_IMAGE,
+            baseLayer: new maptalks.TileLayer('tile', {
+                urlTemplate: TILE_IMAGE,
                 subdomains: [1, 2, 3],
-                renderer:'canvas'
+                renderer: 'canvas'
             })
         };
         map = new maptalks.Map(container, option);
@@ -40,12 +40,12 @@ describe('Map.Anim', function () {
             done();
         });
         map.animateTo({
-            center : center,
-            zoom : zoom,
-            pitch : pitch,
-            bearing : bearing
+            center: center,
+            zoom: zoom,
+            pitch: pitch,
+            bearing: bearing
         }, {
-            'duration' : 300
+            'duration': 300
         });
     });
 
@@ -62,12 +62,12 @@ describe('Map.Anim', function () {
             done();
         });
         map.flyTo({
-            center : center,
-            zoom : zoom,
-            pitch : pitch,
-            bearing : bearing
+            center: center,
+            zoom: zoom,
+            pitch: pitch,
+            bearing: bearing
         }, {
-            'duration' : 300
+            'duration': 300
         });
     });
 
@@ -80,10 +80,10 @@ describe('Map.Anim', function () {
             done();
         });
         map.animateTo({
-            pitch : pitch,
-            bearing : bearing
+            pitch: pitch,
+            bearing: bearing
         }, {
-            'duration' : 300
+            'duration': 300
         });
     });
 
@@ -94,9 +94,9 @@ describe('Map.Anim', function () {
             done();
         });
         map.animateTo({
-            zoom : zoom
+            zoom: zoom
         }, {
-            'duration' : 300
+            'duration': 300
         });
     });
 
@@ -109,9 +109,9 @@ describe('Map.Anim', function () {
             done();
         });
         map.animateTo({
-            zoom : zoom
+            zoom: zoom
         }, {
-            'duration' : 300
+            'duration': 300
         });
     });
 
@@ -158,9 +158,9 @@ describe('Map.Anim', function () {
             }
         });
         map.animateTo({
-            zoom : zoom
+            zoom: zoom
         }, {
-            'duration' : 300
+            'duration': 300
         });
         setTimeout(function () {
             happen.once(container, {
@@ -168,5 +168,167 @@ describe('Map.Anim', function () {
                 detail: 100
             });
         }, 100);
+    });
+
+
+    it('bearing>180', function (done) {
+        map.setView({
+            bearing: 210
+        });
+        setTimeout(() => {
+            expect(map.getBearing()).to.be.eql(-150);
+            done();
+        }, 100);
+    });
+
+    it('bearing<-180', function (done) {
+        map.setView({
+            bearing: -210
+        });
+        setTimeout(() => {
+            expect(map.getBearing()).to.be.eql(150);
+            done();
+        }, 100);
+    });
+
+    it('#1888 animateTo repeat', function (done) {
+
+        function animateTo(callback) {
+            map.animateTo(
+                {
+                    bearing: 269,
+                    duration: 400,
+                    callName: "setAzimuthalAngle",
+                }, {
+
+            }, frame => {
+                if (frame.state.playState === 'finished') {
+                    callback();
+                }
+            }
+            )
+        }
+        var spy = sinon.spy();
+        map.on('rotate', spy);
+        animateTo(() => {
+            expect(spy.called).to.be.ok();
+            var spy1 = sinon.spy();
+            map.on('rotate', spy1);
+            animateTo(() => {
+                expect(spy1.called).not.to.be.ok();
+                done();
+            });
+        });
+    });
+
+
+    it('bearing > 180 and current bearing>0', function (done) {
+        map.setView({
+            bearing: 175
+        })
+        map.animateTo(
+            {
+                bearing: 220,
+
+                // callName: "setAzimuthalAngle",
+            },
+            {
+                duration: 1000,
+            },
+            frame => {
+                if (frame.state.playState === 'finished') {
+                    expect(frame.styles.bearing).to.be.eql(220);
+                    done();
+                }
+            }
+        )
+    });
+
+    it('bearing <180 and current bearing<0', function (done) {
+        map.setView({
+            bearing: -175
+        })
+        map.animateTo(
+            {
+                bearing: -220,
+
+                // callName: "setAzimuthalAngle",
+            },
+            {
+                duration: 1000,
+            },
+            frame => {
+                if (frame.state.playState === 'finished') {
+                    expect(frame.styles.bearing).to.be.eql(-220);
+                    done();
+                }
+            }
+        )
+    });
+
+    it('#851 bearing reverse', function (done) {
+        map.setView({
+            bearing: -178
+        })
+        map.animateTo(
+            {
+                bearing: 177,
+
+                // callName: "setAzimuthalAngle",
+            }, {
+            duration: 1000,
+            reverse: true
+        },
+            frame => {
+                if (frame.state.playState === 'finished') {
+                    expect(frame.styles.bearing).to.be.eql(-183);
+                    done();
+                }
+            }
+        )
+    });
+
+    it('bearing reverse current bearing>0 and bearing>0', function (done) {
+        map.setView({
+            bearing: 0
+        })
+        map.animateTo(
+            {
+                bearing: 40,
+
+                // callName: "setAzimuthalAngle",
+            }, {
+            duration: 1000,
+            reverse: true
+        },
+            frame => {
+                if (frame.state.playState === 'finished') {
+                    expect(frame.styles.bearing).to.be.eql(-320);
+                    done();
+                }
+            }
+        )
+    });
+
+    it('bearing reverse current bearing<0 and bearing<0', function (done) {
+        map.setView({
+            bearing: 0
+        })
+        map.animateTo(
+            {
+                bearing: -40,
+
+                // callName: "setAzimuthalAngle",
+            }, {
+            duration: 1000,
+            reverse: true
+        },
+            frame => {
+                if (frame.state.playState === 'finished') {
+                    expect(frame.styles.bearing).to.be.eql(320);
+                    done();
+                }
+            }
+        )
     });
 });

--- a/test/map/MapAnimSpec.js
+++ b/test/map/MapAnimSpec.js
@@ -172,21 +172,23 @@ describe('Map.Anim', function () {
 
 
     it('bearing>180', function (done) {
+        const bearing = 180 + Math.floor(Math.random() * 180);
         map.setView({
-            bearing: 210
+            bearing
         });
         setTimeout(() => {
-            expect(map.getBearing()).to.be.eql(-150);
+            expect(map.getBearing()).to.be.eql(-180 + (Math.abs(bearing) - 180));
             done();
         }, 100);
     });
 
     it('bearing<-180', function (done) {
+        const bearing = -180 - Math.floor(Math.random() * 180);
         map.setView({
-            bearing: -210
+            bearing
         });
         setTimeout(() => {
-            expect(map.getBearing()).to.be.eql(150);
+            expect(map.getBearing()).to.be.eql(180 - (Math.abs(bearing) - 180));
             done();
         }, 100);
     });
@@ -226,9 +228,10 @@ describe('Map.Anim', function () {
         map.setView({
             bearing: 175
         })
+        const bearing = 180 + Math.floor(Math.random() * 180);
         map.animateTo(
             {
-                bearing: 220,
+                bearing,
 
                 // callName: "setAzimuthalAngle",
             },
@@ -237,7 +240,7 @@ describe('Map.Anim', function () {
             },
             frame => {
                 if (frame.state.playState === 'finished') {
-                    expect(frame.styles.bearing).to.be.eql(220);
+                    expect(frame.styles.bearing).to.be.eql(bearing);
                     done();
                 }
             }
@@ -248,9 +251,10 @@ describe('Map.Anim', function () {
         map.setView({
             bearing: -175
         })
+        const bearing = -180 - Math.floor(Math.random() * 180);
         map.animateTo(
             {
-                bearing: -220,
+                bearing,
 
                 // callName: "setAzimuthalAngle",
             },
@@ -259,7 +263,7 @@ describe('Map.Anim', function () {
             },
             frame => {
                 if (frame.state.playState === 'finished') {
-                    expect(frame.styles.bearing).to.be.eql(-220);
+                    expect(frame.styles.bearing).to.be.eql(bearing);
                     done();
                 }
             }
@@ -292,9 +296,10 @@ describe('Map.Anim', function () {
         map.setView({
             bearing: 0
         })
+        const bearing = Math.floor(Math.random() * 180);
         map.animateTo(
             {
-                bearing: 40,
+                bearing,
 
                 // callName: "setAzimuthalAngle",
             }, {
@@ -303,7 +308,7 @@ describe('Map.Anim', function () {
         },
             frame => {
                 if (frame.state.playState === 'finished') {
-                    expect(frame.styles.bearing).to.be.eql(-320);
+                    expect(frame.styles.bearing).to.be.eql(-(360 - bearing));
                     done();
                 }
             }
@@ -314,9 +319,10 @@ describe('Map.Anim', function () {
         map.setView({
             bearing: 0
         })
+        const bearing = -Math.floor(Math.random() * 180);
         map.animateTo(
             {
-                bearing: -40,
+                bearing,
 
                 // callName: "setAzimuthalAngle",
             }, {
@@ -325,7 +331,7 @@ describe('Map.Anim', function () {
         },
             frame => {
                 if (frame.state.playState === 'finished') {
-                    expect(frame.styles.bearing).to.be.eql(320);
+                    expect(frame.styles.bearing).to.be.eql(360 + bearing);
                     done();
                 }
             }

--- a/test/map/MapAnimSpec.js
+++ b/test/map/MapAnimSpec.js
@@ -270,7 +270,7 @@ describe('Map.Anim', function () {
         )
     });
 
-    it('#851 bearing reverse', function (done) {
+    it('#851 bearing counterclockwise', function (done) {
         map.setView({
             bearing: -178
         })
@@ -281,7 +281,7 @@ describe('Map.Anim', function () {
                 // callName: "setAzimuthalAngle",
             }, {
             duration: 1000,
-            reverse: true
+            counterclockwise: true
         },
             frame => {
                 if (frame.state.playState === 'finished') {
@@ -292,7 +292,7 @@ describe('Map.Anim', function () {
         )
     });
 
-    it('bearing reverse current bearing>0 and bearing>0', function (done) {
+    it('bearing counterclockwise current bearing>0 and bearing>0', function (done) {
         map.setView({
             bearing: 0
         })
@@ -304,7 +304,7 @@ describe('Map.Anim', function () {
                 // callName: "setAzimuthalAngle",
             }, {
             duration: 1000,
-            reverse: true
+            counterclockwise: true
         },
             frame => {
                 if (frame.state.playState === 'finished') {
@@ -315,7 +315,7 @@ describe('Map.Anim', function () {
         )
     });
 
-    it('bearing reverse current bearing<0 and bearing<0', function (done) {
+    it('bearing counterclockwise current bearing<0 and bearing<0', function (done) {
         map.setView({
             bearing: 0
         })
@@ -327,7 +327,7 @@ describe('Map.Anim', function () {
                 // callName: "setAzimuthalAngle",
             }, {
             duration: 1000,
-            reverse: true
+            counterclockwise: true
         },
             frame => {
                 if (frame.state.playState === 'finished') {


### PR DESCRIPTION
fix #851 

```js
   map.setView({
                bearing: -178
 })
map.animateTo(
                {
                    bearing: 177,

                    // callName: "setAzimuthalAngle",
                }, {
                duration: 1000,
                counterclockwise: true
            },
                frame => {
                    console.log(frame);
                }
)

```