### PR TITLE
use babel to transpile ts codes to es5 excluding plugins causing perf issue

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,7 +2,12 @@ module.exports = {
   "presets": [
     ["@babel/env", {
       "loose": true,
-      "modules": false
+      "modules": false,
+      "exclude": [
+        "transform-destructuring",
+        "transform-spread",
+        "transform-parameters"
+      ]
     }]
   ],
   "plugins": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,6 +35,10 @@ const rollupPlugins = [
     commonjs(),
     typescript({
          sourceMap: true
+    }),
+    babel({
+        extensions: [".ts"],
+        babelHelpers: 'bundled'
     })
 ];
 

--- a/src/layer/tile/TileLayer.ts
+++ b/src/layer/tile/TileLayer.ts
@@ -257,7 +257,9 @@ class TileLayer extends Layer {
     forceReload() {
         this.fire('forcereloadstart');
         this.clear();
-        this.load();
+        if (this._renderer) {
+            this._renderer.setToRedraw();
+        }
         this.fire('forcereloadend');
         return this;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     // ask tsc not to mess up with for ... of
     "downlevelIteration": true,
     "module": "esnext",
-    "target": "es5",
+    "target": "es6",
     "jsx": "preserve",
     "lib": [
       "es2015",


### PR DESCRIPTION
该pr是 #2398 的进一步补充。
通过对babel的配置，取消对解构，参数数组等语法的编译，来解决 #2398 中尝试解决的性能问题。

主要包括两个步骤：
* tsconfig 中将编译目标改为es6
* 改用babel将es6语法编译为es5
* 在babel中禁用对destructuring，spread，parameters等语法转换

进一步思考：
也许核心库只需要少数几个关键的编译选项，例如[class编译为函数](https://babeljs.io/docs/babel-plugin-transform-classes)，就能让插件正常工作，这样能尽量避免编译产生的性能问题，减少代码体积，也能提高编译速度。