### PR TITLE
Canvas simulates gradient path

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "@maptalks/feature-filter": "^1.3.0",
     "@maptalks/function-type": "^1.3.1",
+    "colorin": "^0.6.0",
     "frustum-intersects": "^0.1.0",
     "lineclip": "^1.1.5",
     "rbush": "^2.0.2",

--- a/src/core/Canvas.ts
+++ b/src/core/Canvas.ts
@@ -668,6 +668,9 @@ const Canvas = {
                     const tempStep = Math.min((n * minStep), percent);
                     const [r, g, b, a] = colorIn.getColor(step + tempStep);
                     color = `rgba(${r},${g},${b},${a})`;
+                    if (color === preColor) {
+                        continue;
+                    }
                     const point = getSegmentPercentPoint(prePoint, currentPoint, tempStep / percent);
                     currentX = point.x;
                     currentY = point.y;

--- a/src/core/Canvas.ts
+++ b/src/core/Canvas.ts
@@ -103,6 +103,45 @@ function getCubicControlPoints(x0, y0, x1, y1, x2, y2, x3, y3, smoothValue, t) {
     }
 }
 
+
+function pathDistance(points: Array<Point>) {
+    if (points.length < 2) {
+        return 0;
+    }
+    let distance = 0;
+    for (let i = 1, len = points.length; i < len; i++) {
+        const p1 = points[i - 1], p2 = points[i];
+        distance += p1.distanceTo(p2);
+    }
+    return distance;
+}
+
+function getColorInMinStep(colorIn: any) {
+    const colors = colorIn.colors || [];
+    const len = colors.length;
+    const steps = [];
+    for (let i = 0; i < len; i++) {
+        steps[i] = colors[i][0];
+    }
+    steps.sort((a, b) => {
+        return a - b;
+    });
+    let min = Infinity;
+    for (let i = 1; i < len; i++) {
+        const step1 = steps[i - 1], step2 = steps[i];
+        const stepOffset = step2 - step1;
+        min = Math.min(min, stepOffset);
+    }
+    return min;
+
+}
+
+function getSegmentPercentPoint(p1: Point, p2: Point, percent: number) {
+    const x1 = p1.x, y1 = p1.y, x2 = p2.x, y2 = p2.y;
+    const dx = x2 - x1, dy = y2 - y1;
+    return new Point(x1 + dx * percent, y1 + dy * percent);
+}
+
 const Canvas = {
     getCanvas2DContext(canvas: HTMLCanvasElement) {
         return canvas.getContext('2d', { willReadFrequently: true });
@@ -537,6 +576,110 @@ const Canvas = {
         }
     },
 
+    /**
+     * mock gradient path
+     * 利用颜色插值来模拟渐变的Path
+     * @param ctx 
+     * @param points 
+     * @param lineDashArray 
+     * @param lineOpacity 
+     * @param isRing 
+     * @returns 
+     */
+    _gradientPath(ctx: CanvasRenderingContext2D, points, lineDashArray, lineOpacity, isRing = false) {
+        if (!isNumber(lineOpacity)) {
+            lineOpacity = 1;
+        }
+        if (hitTesting) {
+            lineOpacity = 1;
+        }
+        if (lineOpacity === 0 || ctx.lineWidth === 0) {
+            return;
+        }
+        const alpha = ctx.globalAlpha;
+        ctx.globalAlpha *= lineOpacity;
+        const colorIn = ctx.lineColorIn;
+        //颜色插值的最小步数
+        const minStep = getColorInMinStep(colorIn);
+        const distance = pathDistance(points);
+        let step = 0;
+        let preColor, color;
+        let preX, preY, currentX, currentY, nextPoint;
+
+        const [r, g, b, a] = colorIn.getColor(0);
+        preColor = `rgba(${r},${g},${b},${a})`;
+
+        const firstPoint = points[0];
+        preX = firstPoint.x;
+        preY = firstPoint.y;
+        //check polygon ring
+        if (isRing) {
+            const len = points.length;
+            const lastPoint = points[len - 1];
+            if (!firstPoint.equals(lastPoint)) {
+                points.push(firstPoint);
+            }
+        }
+
+        const dashArrayEnable = lineDashArray && Array.isArray(lineDashArray) && lineDashArray.length > 1;
+
+        const drawSegment = () => {
+            //绘制底色,来掩盖多个segment绘制接头的锯齿
+            if (!dashArrayEnable && nextPoint) {
+                ctx.strokeStyle = color;
+                ctx.beginPath();
+                ctx.moveTo(preX, preY);
+                ctx.lineTo(currentX, currentY);
+                ctx.lineTo(nextPoint.x, nextPoint.y);
+                ctx.stroke();
+            }
+            const grad = ctx.createLinearGradient(preX, preY, currentX, currentY);
+            grad.addColorStop(0, preColor);
+            grad.addColorStop(1, color);
+            ctx.strokeStyle = grad;
+            ctx.beginPath();
+            ctx.moveTo(preX, preY);
+            ctx.lineTo(currentX, currentY);
+            ctx.stroke();
+            preColor = color;
+            preX = currentX;
+            preY = currentY;
+        }
+
+        for (let i = 1, len = points.length; i < len; i++) {
+            const prePoint = points[i - 1], currentPoint = points[i];
+            nextPoint = points[i + 1];
+            const x = currentPoint.x, y = currentPoint.y;
+            const dis = currentPoint.distanceTo(prePoint);
+            const percent = dis / distance;
+
+            //segment的步数小于minStep
+            if (percent <= minStep) {
+                const [r, g, b, a] = colorIn.getColor(step + percent);
+                color = `rgba(${r},${g},${b},${a})`;
+                currentX = x;
+                currentY = y;
+                drawSegment();
+            } else {
+                //拆分segment
+                const segments = Math.ceil(percent / minStep);
+                nextPoint = currentPoint;
+                for (let n = 1; n <= segments; n++) {
+                    const tempStep = Math.min((n * minStep), percent);
+                    const [r, g, b, a] = colorIn.getColor(step + tempStep);
+                    color = `rgba(${r},${g},${b},${a})`;
+                    const point = getSegmentPercentPoint(prePoint, currentPoint, tempStep / percent);
+                    currentX = point.x;
+                    currentY = point.y;
+                    drawSegment();
+                }
+            }
+            step += percent;
+        }
+        ctx.globalAlpha = alpha;
+    },
+
+
     //@internal
     _path(ctx, points, lineDashArray?, lineOpacity?, ignoreStrokePattern?) {
         if (!isArrayHasData(points)) {
@@ -582,13 +725,18 @@ const Canvas = {
         }
     },
 
-    path(ctx, points, lineOpacity, fillOpacity?, lineDashArray?) {
+    path(ctx: CanvasRenderingContext2D, points, lineOpacity, fillOpacity?, lineDashArray?) {
         if (!isArrayHasData(points)) {
             return;
         }
-        ctx.beginPath();
-        ctx.moveTo(points[0].x, points[0].y);
-        Canvas._path(ctx, points, lineDashArray, lineOpacity);
+
+        if (ctx.lineColorIn) {
+            this._gradientPath(ctx, points, lineDashArray, lineOpacity);
+        } else {
+            ctx.beginPath();
+            ctx.moveTo(points[0].x, points[0].y);
+            Canvas._path(ctx, points, lineDashArray, lineOpacity);
+        }
         Canvas._stroke(ctx, lineOpacity);
     },
 
@@ -654,6 +802,8 @@ const Canvas = {
             }
 
         }
+        const lineColorIn = ctx.lineColorIn;
+        const lineWidth = ctx.lineWidth;
         // function fillPolygon(points, i, op) {
         //     Canvas.fillCanvas(ctx, op, points[i][0].x, points[i][0].y);
         // }
@@ -664,6 +814,10 @@ const Canvas = {
             for (i = 0, len = points.length; i < len; i++) {
                 if (!isArrayHasData(points[i])) {
                     continue;
+                }
+                //渐变时忽略不在绘制storke
+                if (lineColorIn) {
+                    ctx.lineWidth = 0.1;
                 }
                 Canvas._ring(ctx, points[i], null, 0, true);
                 op = fillOpacity;
@@ -679,6 +833,10 @@ const Canvas = {
                     ctx.fillStyle = '#fff';
                 }
                 Canvas._stroke(ctx, 0);
+                ctx.lineWidth = lineWidth;
+                if (lineColorIn) {
+                    Canvas._gradientPath(ctx, points, null, 0, true);
+                }
             }
             ctx.restore();
         }
@@ -687,7 +845,9 @@ const Canvas = {
             if (!isArrayHasData(points[i])) {
                 continue;
             }
-
+            if (lineColorIn) {
+                ctx.lineWidth = 0.1;
+            }
             if (smoothness) {
                 Canvas.paintSmoothLine(ctx, points[i], lineOpacity, smoothness, true);
                 ctx.closePath();
@@ -711,6 +871,10 @@ const Canvas = {
                 }
             }
             Canvas._stroke(ctx, lineOpacity);
+            ctx.lineWidth = lineWidth;
+            if (lineColorIn) {
+                Canvas._gradientPath(ctx, points[i], lineDashArray, lineOpacity, true);
+            }
         }
         //还原fillStyle
         if (ctx.fillStyle !== fillStyle) {
@@ -1221,6 +1385,7 @@ function copyProperties(ctx: CanvasRenderingContext2D, savedCtx) {
     ctx.shadowOffsetX = savedCtx.shadowOffsetX;
     ctx.shadowOffsetY = savedCtx.shadowOffsetY;
     ctx.strokeStyle = savedCtx.strokeStyle;
+    ctx.lineColorIn = savedCtx.lineColorIn;
 }
 
 function setLineDash(ctx: CanvasRenderingContext2D, lineDashArray: number[]) {

--- a/src/core/Canvas.ts
+++ b/src/core/Canvas.ts
@@ -117,6 +117,9 @@ function pathDistance(points: Array<Point>) {
 }
 
 function getColorInMinStep(colorIn: any) {
+    if (isNumber(colorIn.minStep)) {
+        return colorIn.minStep;
+    }
     const colors = colorIn.colors || [];
     const len = colors.length;
     const steps = [];
@@ -132,6 +135,7 @@ function getColorInMinStep(colorIn: any) {
         const stepOffset = step2 - step1;
         min = Math.min(min, stepOffset);
     }
+    colorIn.minStep = min;
     return min;
 
 }

--- a/src/renderer/geometry/VectorRenderer.ts
+++ b/src/renderer/geometry/VectorRenderer.ts
@@ -291,13 +291,14 @@ const lineStringInclude = {
     },
 
     //@internal
-    _paintOn(ctx: CanvasRenderingContext2D, points: Point[], lineOpacity?: number, fillOpacity?: number, dasharray?: number[]) {
+    _paintOn(ctx: CanvasRenderingContext2D, points: Point[], lineOpacity?: number, fillOpacity?: number, dasharray?: number[], lineColorIn?: any) {
         const r = isWithinPixel(this._painter);
         if (r.within) {
             Canvas.pixelRect(ctx, r.center, lineOpacity, fillOpacity);
         } else if (this.options['smoothness']) {
             Canvas.paintSmoothLine(ctx, points, lineOpacity, this.options['smoothness'], false, this._animIdx, this._animTailRatio);
         } else {
+            ctx.lineColorIn = lineColorIn;
             Canvas.path(ctx, points, lineOpacity, null, dasharray);
         }
         this._paintArrow(ctx, points, lineOpacity);
@@ -478,11 +479,12 @@ const polygonInclude = {
     },
 
     //@internal
-    _paintOn(ctx: CanvasRenderingContext2D, points: Point[], lineOpacity?: number, fillOpacity?: number, dasharray?: number[]) {
+    _paintOn(ctx: CanvasRenderingContext2D, points: Point[], lineOpacity?: number, fillOpacity?: number, dasharray?: number[], lineColorIn?: any) {
         const r = isWithinPixel(this._painter);
         if (r.within) {
             Canvas.pixelRect(ctx, r.center, lineOpacity, fillOpacity);
         } else {
+            ctx.lineColorIn = lineColorIn;
             Canvas.polygon(ctx, points, lineOpacity, fillOpacity, dasharray, this.options['smoothness']);
         }
         return this._getRenderBBOX(ctx, points);

--- a/src/symbol/index.ts
+++ b/src/symbol/index.ts
@@ -127,6 +127,7 @@ export type LineSymbol = {
     linePatternFile?: string;
     lineDx?: SymbolNumberType;
     lineDy?: SymbolNumberType;
+    lineGradientProperty?: string;
 }
 
 export type FillSymbol = {

--- a/src/types/typings.ts
+++ b/src/types/typings.ts
@@ -17,5 +17,6 @@ declare global {
         isClip: boolean;
         isMultiClip: boolean;
         dpr: number;
+        lineColorIn: any;
     }
 }

--- a/test/geometry/symbol/StrokeAndFillSpec.js
+++ b/test/geometry/symbol/StrokeAndFillSpec.js
@@ -6,7 +6,7 @@ describe('StrokeAndFillSpec', function () {
     var patternImage = 'data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7';
 
     beforeEach(function () {
-        var setups = COMMON_CREATE_MAP(center);
+        var setups = COMMON_CREATE_MAP(center, null, { width: 800, height: 600 });
         container = setups.container;
         map = setups.map;
     });
@@ -19,9 +19,9 @@ describe('StrokeAndFillSpec', function () {
     describe('pattern', function () {
         it('fill pattern', function (done) {
             var circle = new maptalks.Circle(center, 10, {
-                symbol:{
-                    'polygonPatternFile' : 'resources/pattern2.png',
-                    'polygonOpacity' : 1
+                symbol: {
+                    'polygonPatternFile': 'resources/pattern2.png',
+                    'polygonOpacity': 1
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -34,10 +34,10 @@ describe('StrokeAndFillSpec', function () {
 
         it('fill pattern with polygonPatternDx', function (done) {
             var circle = new maptalks.Circle(center, 10, {
-                symbol:{
-                    'polygonPatternFile' : 'resources/pattern2.png',
-                    'polygonPatternDx' : 5,
-                    'polygonOpacity' : 1
+                symbol: {
+                    'polygonPatternFile': 'resources/pattern2.png',
+                    'polygonPatternDx': 5,
+                    'polygonOpacity': 1
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -50,12 +50,12 @@ describe('StrokeAndFillSpec', function () {
 
         it('line pattern', function (done) {
             var line = new maptalks.LineString([center, center.add(0, -0.0001)], {
-                symbol:{
-                    'linePatternFile' : 'resources/pattern2.png',
-                    'lineOpacity' : 1,
-                    'lineWidth' : 5,
-                    'polygonFill' : '#000',
-                    'polygonOpacity' : 0
+                symbol: {
+                    'linePatternFile': 'resources/pattern2.png',
+                    'lineOpacity': 1,
+                    'lineWidth': 5,
+                    'polygonFill': '#000',
+                    'polygonOpacity': 0
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -68,13 +68,13 @@ describe('StrokeAndFillSpec', function () {
 
         it('line pattern with linePatternDx', function (done) {
             var line = new maptalks.LineString([center, center.add(0.0001, 0)], {
-                symbol:{
-                    'linePatternFile' : 'resources/pattern2.png',
-                    'linePatternDx' : 2,
-                    'lineOpacity' : 1,
-                    'lineWidth' : 5,
-                    'polygonFill' : '#000',
-                    'polygonOpacity' : 0
+                symbol: {
+                    'linePatternFile': 'resources/pattern2.png',
+                    'linePatternDx': 2,
+                    'lineOpacity': 1,
+                    'lineWidth': 5,
+                    'polygonFill': '#000',
+                    'polygonOpacity': 0
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -87,9 +87,9 @@ describe('StrokeAndFillSpec', function () {
 
         it('fill pattern with base64', function (done) {
             var circle = new maptalks.Circle(center, 10, {
-                symbol:{
-                    'polygonPatternFile' : patternImage,
-                    'polygonOpacity' : 1
+                symbol: {
+                    'polygonPatternFile': patternImage,
+                    'polygonOpacity': 1
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -102,12 +102,12 @@ describe('StrokeAndFillSpec', function () {
 
         it('line pattern with base64', function (done) {
             var circle = new maptalks.Circle(center, 10, {
-                symbol:{
-                    'linePatternFile' : 'url(' + patternImage + ')',
-                    'lineOpacity' : 1,
-                    'lineWidth' : 5,
-                    'polygonFill' : '#000',
-                    'polygonOpacity' : 0
+                symbol: {
+                    'linePatternFile': 'url(' + patternImage + ')',
+                    'lineOpacity': 1,
+                    'lineWidth': 5,
+                    'polygonFill': '#000',
+                    'polygonOpacity': 0
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -120,12 +120,12 @@ describe('StrokeAndFillSpec', function () {
 
         it('vector marker fill pattern', function (done) {
             var circle = new maptalks.Marker(center, {
-                symbol:{
-                    'markerType' : 'ellipse',
-                    'markerFillPatternFile' : 'resources/pattern.png',
-                    'markerFillOpacity' : 1,
-                    'markerWidth' : 20,
-                    'markerHeight' : 20
+                symbol: {
+                    'markerType': 'ellipse',
+                    'markerFillPatternFile': 'resources/pattern.png',
+                    'markerFillOpacity': 1,
+                    'markerWidth': 20,
+                    'markerHeight': 20
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -138,14 +138,14 @@ describe('StrokeAndFillSpec', function () {
 
         it('vector marker line pattern', function (done) {
             var circle = new maptalks.Marker(center, {
-                symbol:{
-                    'markerType' : 'ellipse',
-                    'markerLinePatternFile' : 'resources/pattern.png',
-                    'markerLineOpacity' : 1,
-                    'markerLineWidth' : 5,
-                    'markerFillOpacity' : 0,
-                    'markerWidth' : 20,
-                    'markerHeight' : 20
+                symbol: {
+                    'markerType': 'ellipse',
+                    'markerLinePatternFile': 'resources/pattern.png',
+                    'markerLineOpacity': 1,
+                    'markerLineWidth': 5,
+                    'markerFillOpacity': 0,
+                    'markerWidth': 20,
+                    'markerHeight': 20
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -158,12 +158,12 @@ describe('StrokeAndFillSpec', function () {
 
         it('vector marker fill pattern with base64', function (done) {
             var circle = new maptalks.Marker(center, {
-                symbol:{
-                    'markerType' : 'ellipse',
-                    'markerFillPatternFile' : patternImage,
-                    'markerFillOpacity' : 1,
-                    'markerWidth' : 20,
-                    'markerHeight' : 20
+                symbol: {
+                    'markerType': 'ellipse',
+                    'markerFillPatternFile': patternImage,
+                    'markerFillOpacity': 1,
+                    'markerWidth': 20,
+                    'markerHeight': 20
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -176,14 +176,14 @@ describe('StrokeAndFillSpec', function () {
 
         it('vector marker line pattern with base64', function (done) {
             var circle = new maptalks.Marker(center, {
-                symbol:{
-                    'markerType' : 'ellipse',
-                    'markerLinePatternFile' : 'url(' + patternImage + ')',
-                    'markerLineOpacity' : 1,
-                    'markerLineWidth' : 5,
-                    'markerFillOpacity' : 0,
-                    'markerWidth' : 20,
-                    'markerHeight' : 20
+                symbol: {
+                    'markerType': 'ellipse',
+                    'markerLinePatternFile': 'url(' + patternImage + ')',
+                    'markerLineOpacity': 1,
+                    'markerLineWidth': 5,
+                    'markerFillOpacity': 0,
+                    'markerWidth': 20,
+                    'markerHeight': 20
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -199,11 +199,11 @@ describe('StrokeAndFillSpec', function () {
     describe('radial gradient', function () {
         it('fill radial gradient', function (done) {
             var circle = new maptalks.Circle(center, 10, {
-                symbol:{
-                    'polygonFill' : {
-                        type : 'radial',
-                        places : [0.5, 0.5, 1, 0.5, 0.5, 0],
-                        colorStops : [
+                symbol: {
+                    'polygonFill': {
+                        type: 'radial',
+                        places: [0.5, 0.5, 1, 0.5, 0.5, 0],
+                        colorStops: [
                             [0.00, 'red'],
                             [1 / 6, 'orange'],
                             [2 / 6, 'yellow'],
@@ -213,7 +213,7 @@ describe('StrokeAndFillSpec', function () {
                             [1.00, 'white'],
                         ]
                     },
-                    'polygonOpacity' : 1
+                    'polygonOpacity': 1
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -226,10 +226,10 @@ describe('StrokeAndFillSpec', function () {
 
         it('fill radial gradient 2', function (done) {
             var circle = new maptalks.Circle(center, 10, {
-                symbol:{
-                    'polygonFill' : {
-                        type : 'radial',
-                        colorStops : [
+                symbol: {
+                    'polygonFill': {
+                        type: 'radial',
+                        colorStops: [
                             [0.00, 'red'],
                             [1 / 6, 'orange'],
                             [2 / 6, 'yellow'],
@@ -239,7 +239,7 @@ describe('StrokeAndFillSpec', function () {
                             [1.00, 'white'],
                         ]
                     },
-                    'polygonOpacity' : 1
+                    'polygonOpacity': 1
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -252,10 +252,10 @@ describe('StrokeAndFillSpec', function () {
 
         it('line radial gradient', function (done) {
             var circle = new maptalks.Circle(center, 10, {
-                symbol:{
-                    'lineColor' : {
-                        type : 'radial',
-                        colorStops : [
+                symbol: {
+                    'lineColor': {
+                        type: 'radial',
+                        colorStops: [
                             [0.00, 'red'],
                             [1 / 6, 'orange'],
                             [2 / 6, 'yellow'],
@@ -265,9 +265,9 @@ describe('StrokeAndFillSpec', function () {
                             [1.00, 'white'],
                         ]
                     },
-                    'lineWidth' : 3,
-                    'lineOpacity' : 1,
-                    'polygonOpacity' : 0
+                    'lineWidth': 3,
+                    'lineOpacity': 1,
+                    'polygonOpacity': 0
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -281,11 +281,11 @@ describe('StrokeAndFillSpec', function () {
 
         it('vector marker', function (done) {
             var circle = new maptalks.Marker(center, {
-                symbol:{
-                    'markerType' : 'ellipse',
-                    'markerLineColor' : {
-                        type : 'radial',
-                        colorStops : [
+                symbol: {
+                    'markerType': 'ellipse',
+                    'markerLineColor': {
+                        type: 'radial',
+                        colorStops: [
                             [0.00, 'red'],
                             [1 / 6, 'orange'],
                             [2 / 6, 'yellow'],
@@ -295,10 +295,10 @@ describe('StrokeAndFillSpec', function () {
                             [1.00, 'white'],
                         ]
                     },
-                    'markerLineWidth' : 3,
-                    'markerFillOpacity' : 0,
-                    'markerWidth' : 20,
-                    'markerHeight' : 20
+                    'markerLineWidth': 3,
+                    'markerFillOpacity': 0,
+                    'markerWidth': 20,
+                    'markerHeight': 20
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -316,11 +316,11 @@ describe('StrokeAndFillSpec', function () {
 
         it('fill linear gradient', function (done) {
             var circle = new maptalks.Circle(center, 10, {
-                symbol:{
-                    'polygonFill' : {
-                        type : 'linear',
-                        places : [0, 0, 0.5, 0],
-                        colorStops : [
+                symbol: {
+                    'polygonFill': {
+                        type: 'linear',
+                        places: [0, 0, 0.5, 0],
+                        colorStops: [
                             [0.00, 'red'],
                             [1 / 6, 'orange'],
                             [2 / 6, 'yellow'],
@@ -330,7 +330,7 @@ describe('StrokeAndFillSpec', function () {
                             [1.00, 'white'],
                         ]
                     },
-                    'polygonOpacity' : 1
+                    'polygonOpacity': 1
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -343,10 +343,10 @@ describe('StrokeAndFillSpec', function () {
 
         it('fill linear gradient 2', function (done) {
             var circle = new maptalks.Circle(center, 10, {
-                symbol:{
-                    'polygonFill' : {
-                        type : 'linear',
-                        colorStops : [
+                symbol: {
+                    'polygonFill': {
+                        type: 'linear',
+                        colorStops: [
                             [0.00, 'red'],
                             [1 / 6, 'orange'],
                             [2 / 6, 'yellow'],
@@ -356,7 +356,7 @@ describe('StrokeAndFillSpec', function () {
                             [1.00, 'white'],
                         ]
                     },
-                    'polygonOpacity' : 1
+                    'polygonOpacity': 1
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -368,10 +368,10 @@ describe('StrokeAndFillSpec', function () {
         });
         it('line linear gradient', function (done) {
             var circle = new maptalks.Circle(center, 10, {
-                symbol:{
-                    'lineColor' : {
-                        type : 'linear',
-                        colorStops : [
+                symbol: {
+                    'lineColor': {
+                        type: 'linear',
+                        colorStops: [
                             [0.00, 'red'],
                             [1 / 6, 'orange'],
                             [2 / 6, 'yellow'],
@@ -381,9 +381,9 @@ describe('StrokeAndFillSpec', function () {
                             [1.00, 'white'],
                         ]
                     },
-                    'lineWidth' : 3,
-                    'lineOpacity' : 1,
-                    'polygonOpacity' : 0
+                    'lineWidth': 3,
+                    'lineOpacity': 1,
+                    'polygonOpacity': 0
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -396,18 +396,18 @@ describe('StrokeAndFillSpec', function () {
 
         it('vector marker', function (done) {
             var circle = new maptalks.Marker(center, {
-                symbol:{
-                    'markerType' : 'ellipse',
-                    'markerFill' : {
-                        type : 'linear',
-                        colorStops : [
+                symbol: {
+                    'markerType': 'ellipse',
+                    'markerFill': {
+                        type: 'linear',
+                        colorStops: [
                             [0.00, 'red'],
                             [1.00, 'white'],
                         ]
                     },
-                    'markerFillOpacity' : 1,
-                    'markerWidth' : 20,
-                    'markerHeight' : 20
+                    'markerFillOpacity': 1,
+                    'markerWidth': 20,
+                    'markerHeight': 20
                 }
             });
             var v = new maptalks.VectorLayer('v').addTo(map);
@@ -444,8 +444,8 @@ describe('StrokeAndFillSpec', function () {
                     done();
                 });
                 line.setSymbol({
-                    'lineWidth' : 2,
-                    'lineDx'   : 10
+                    'lineWidth': 2,
+                    'lineDx': 10
                 });
             });
             v.addGeometry(line);
@@ -466,11 +466,95 @@ describe('StrokeAndFillSpec', function () {
                     done();
                 });
                 line.setSymbol({
-                    'lineWidth' : 2,
-                    'lineDy'   : 10
+                    'lineWidth': 2,
+                    'lineDy': 10
                 });
             });
             v.addGeometry(line);
         });
     });
+
+
+
+    it('#2123 #1712 Canvas simulates gradient path ', function (done) {
+        var line = new maptalks.LineString(
+            [
+                {
+                    "x": 116.28890991210938,
+                    "y": 39.98369699673039
+                },
+                {
+                    "x": 116.43619537353516,
+                    "y": 39.98737978325713
+                },
+                {
+                    "x": 116.48529052734374,
+                    "y": 39.95554342883535
+                },
+                {
+                    "x": 116.47979736328125,
+                    "y": 39.84887587825816
+                },
+                {
+                    "x": 116.46743774414061,
+                    "y": 39.83754093169162
+                },
+                {
+                    "x": 116.45267486572266,
+                    "y": 39.8314772852108
+                },
+                {
+                    "x": 116.28135681152342,
+                    "y": 39.829104408261685
+                },
+                {
+                    "x": 116.27071380615233,
+                    "y": 39.883396390093075
+                },
+                {
+                    "x": 116.26831054687501,
+                    "y": 39.89446035777916
+                },
+                {
+                    "x": 116.26899719238281,
+                    "y": 39.96791137735179
+                },
+                {
+                    "x": 116.28719329833983,
+                    "y": 39.98290780236021
+                }
+            ], {
+            symbol: {
+                // linear gradient
+                'lineColor': {
+                    'type': 'linear',
+                    'colorStops': [
+                        [0.00, 'red'],
+                        [1 / 4, 'orange'],
+                        [2 / 4, 'green'],
+                        [3 / 4, 'aqua'],
+                        [1.00, 'white']
+                    ]
+                },
+                'lineWidth': 4
+            }
+        })
+        var layer = new maptalks.VectorLayer('v').addTo(map);
+        line.addTo(layer);
+        const coordinates = line.getCoordinates();
+        const first = coordinates[0], last = coordinates[coordinates.length - 1];
+        map.fitExtent(layer.getExtent());
+        const centerPt = map.coordinateToContainerPoint(map.getCenter());
+
+        setTimeout(() => {
+            const p1 = map.coordinateToContainerPoint(first).sub(centerPt);
+            const p2 = map.coordinateToContainerPoint(last).sub(centerPt);
+            expect(layer).to.be.painted(p1.x, p1.y, [255,3,0]);
+            expect(layer).to.be.painted(p2.x, p2.y, [249, 255, 255]);
+            done();
+        }, 1000);
+
+
+    });
+
 });

--- a/test/geometry/symbol/StrokeAndFillSpec.js
+++ b/test/geometry/symbol/StrokeAndFillSpec.js
@@ -4,6 +4,59 @@ describe('StrokeAndFillSpec', function () {
     var map;
     var center = new maptalks.Coordinate(118.846825, 32.046534);
     var patternImage = 'data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7';
+    const lineCoordinates = [
+        {
+            "x": 116.28890991210938,
+            "y": 39.98369699673039
+        },
+        {
+            "x": 116.43619537353516,
+            "y": 39.98737978325713
+        },
+        {
+            "x": 116.48529052734374,
+            "y": 39.95554342883535
+        },
+        {
+            "x": 116.47979736328125,
+            "y": 39.84887587825816
+        },
+        {
+            "x": 116.46743774414061,
+            "y": 39.83754093169162
+        },
+        {
+            "x": 116.45267486572266,
+            "y": 39.8314772852108
+        },
+        {
+            "x": 116.28135681152342,
+            "y": 39.829104408261685
+        },
+        {
+            "x": 116.27071380615233,
+            "y": 39.883396390093075
+        },
+        {
+            "x": 116.26831054687501,
+            "y": 39.89446035777916
+        },
+        {
+            "x": 116.26899719238281,
+            "y": 39.96791137735179
+        },
+        {
+            "x": 116.28719329833983,
+            "y": 39.98290780236021
+        }
+    ];
+    const lineColorStops = [
+        [0.00, 'red'],
+        [1 / 4, 'orange'],
+        [2 / 4, 'green'],
+        [3 / 4, 'aqua'],
+        [1.00, 'white']
+    ];
 
     beforeEach(function () {
         var setups = COMMON_CREATE_MAP(center, null, { width: 800, height: 600 });
@@ -475,86 +528,99 @@ describe('StrokeAndFillSpec', function () {
     });
 
 
+    describe('lineColor gradient', function () {
 
-    it('#2123 #1712 Canvas simulates gradient path ', function (done) {
-        var line = new maptalks.LineString(
-            [
-                {
-                    "x": 116.28890991210938,
-                    "y": 39.98369699673039
-                },
-                {
-                    "x": 116.43619537353516,
-                    "y": 39.98737978325713
-                },
-                {
-                    "x": 116.48529052734374,
-                    "y": 39.95554342883535
-                },
-                {
-                    "x": 116.47979736328125,
-                    "y": 39.84887587825816
-                },
-                {
-                    "x": 116.46743774414061,
-                    "y": 39.83754093169162
-                },
-                {
-                    "x": 116.45267486572266,
-                    "y": 39.8314772852108
-                },
-                {
-                    "x": 116.28135681152342,
-                    "y": 39.829104408261685
-                },
-                {
-                    "x": 116.27071380615233,
-                    "y": 39.883396390093075
-                },
-                {
-                    "x": 116.26831054687501,
-                    "y": 39.89446035777916
-                },
-                {
-                    "x": 116.26899719238281,
-                    "y": 39.96791137735179
-                },
-                {
-                    "x": 116.28719329833983,
-                    "y": 39.98290780236021
+
+        it('#2123 #1712 Canvas simulates gradient path ', function (done) {
+            var line = new maptalks.LineString(lineCoordinates, {
+                symbol: {
+                    // linear gradient
+                    'lineColor': {
+                        'type': 'linear',
+                        'colorStops': lineColorStops
+                    },
+                    'lineWidth': 4
                 }
-            ], {
-            symbol: {
-                // linear gradient
-                'lineColor': {
-                    'type': 'linear',
-                    'colorStops': [
-                        [0.00, 'red'],
-                        [1 / 4, 'orange'],
-                        [2 / 4, 'green'],
-                        [3 / 4, 'aqua'],
-                        [1.00, 'white']
-                    ]
+            })
+            var layer = new maptalks.VectorLayer('v').addTo(map);
+            line.addTo(layer);
+            const coordinates = line.getCoordinates();
+            const first = coordinates[0], last = coordinates[coordinates.length - 1];
+            map.fitExtent(layer.getExtent());
+            const centerPt = map.coordinateToContainerPoint(map.getCenter());
+
+            setTimeout(() => {
+                const p1 = map.coordinateToContainerPoint(first).sub(centerPt);
+                const p2 = map.coordinateToContainerPoint(last).sub(centerPt);
+                expect(layer).to.be.painted(p1.x, p1.y, [255, 3, 0]);
+                expect(layer).to.be.painted(p2.x, p2.y, [249, 255, 255]);
+                done();
+            }, 1000);
+
+
+        });
+
+        it('lineColor gradient from lineGradientProperty', function (done) {
+            var line = new maptalks.LineString(lineCoordinates, {
+                symbol: {
+                    // linear gradient
+                    lineGradientProperty: 'gradients',
+                    'lineWidth': 4
                 },
-                'lineWidth': 4
-            }
-        })
-        var layer = new maptalks.VectorLayer('v').addTo(map);
-        line.addTo(layer);
-        const coordinates = line.getCoordinates();
-        const first = coordinates[0], last = coordinates[coordinates.length - 1];
-        map.fitExtent(layer.getExtent());
-        const centerPt = map.coordinateToContainerPoint(map.getCenter());
+                properties: {
+                    gradients: lineColorStops
+                }
+            })
+            var layer = new maptalks.VectorLayer('v').addTo(map);
+            line.addTo(layer);
+            const coordinates = line.getCoordinates();
+            const first = coordinates[0], last = coordinates[coordinates.length - 1];
+            map.fitExtent(layer.getExtent());
+            const centerPt = map.coordinateToContainerPoint(map.getCenter());
 
-        setTimeout(() => {
-            const p1 = map.coordinateToContainerPoint(first).sub(centerPt);
-            const p2 = map.coordinateToContainerPoint(last).sub(centerPt);
-            expect(layer).to.be.painted(p1.x, p1.y, [255,3,0]);
-            expect(layer).to.be.painted(p2.x, p2.y, [249, 255, 255]);
-            done();
-        }, 1000);
+            setTimeout(() => {
+                const p1 = map.coordinateToContainerPoint(first).sub(centerPt);
+                const p2 = map.coordinateToContainerPoint(last).sub(centerPt);
+                expect(layer).to.be.painted(p1.x, p1.y, [255, 3, 0]);
+                expect(layer).to.be.painted(p2.x, p2.y, [249, 255, 255]);
+                done();
+            }, 1000);
 
 
+        });
+
+        it('lineColor gradient from lineGradientProperty and colorStops is flat array', function (done) {
+            const colorStops = [];
+            lineColorStops.forEach(lineColorStop => {
+                colorStops.push(...lineColorStop);
+            });
+            var line = new maptalks.LineString(lineCoordinates, {
+                symbol: {
+                    // linear gradient
+                    lineGradientProperty: 'gradients',
+                    'lineWidth': 4
+                },
+                properties: {
+                    gradients: colorStops
+                }
+            })
+            var layer = new maptalks.VectorLayer('v').addTo(map);
+            line.addTo(layer);
+            const coordinates = line.getCoordinates();
+            const first = coordinates[0], last = coordinates[coordinates.length - 1];
+            map.fitExtent(layer.getExtent());
+            const centerPt = map.coordinateToContainerPoint(map.getCenter());
+
+            setTimeout(() => {
+                const p1 = map.coordinateToContainerPoint(first).sub(centerPt);
+                const p2 = map.coordinateToContainerPoint(last).sub(centerPt);
+                expect(layer).to.be.painted(p1.x, p1.y, [255, 3, 0]);
+                expect(layer).to.be.painted(p2.x, p2.y, [249, 255, 255]);
+                done();
+            }, 1000);
+
+
+        });
     });
 
 });


### PR DESCRIPTION
fix #2123
fix #1712 

canvas模拟webgl 渐变的线条

![{Y W4OQG6RM91_0XG CZ${0](https://github.com/user-attachments/assets/d0d20353-3748-46e1-92b5-57e01b3e3e58)

利用颜色插值绘制多个小的的线段，所以性能会比较差，不适合大规模的数据
