### PR TITLE
Geometry.path support Map View Quadrilateral clip

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@maptalks/function-type": "^1.3.1",
     "frustum-intersects": "^0.1.0",
     "lineclip": "^1.1.5",
+    "polygon-clipping": "^0.15.7",
     "rbush": "^2.0.2",
     "simplify-js": "^1.2.1"
   },

--- a/src/core/util/path.ts
+++ b/src/core/util/path.ts
@@ -548,9 +548,9 @@ export function clipLineByQuadrilateral(path, p1, p2, p3, p4) {
             }
             const cross = getSegmenQuadrilateralIntersections(point1, point2, p1, p2, p3, p4);
 
-            if (cross.length !== 1) {
-                console.error('error:只应该一个交点才对,实际有,', cross.length);
-            }
+            // if (cross.length !== 1) {
+            //     console.error('只应该一个交点才对,实际有,', cross.length);
+            // }
             line.push(...cross)
             if (point3) {
                 const cross1 = getSegmenQuadrilateralIntersections(point2, point3, p1, p2, p3, p4);
@@ -570,9 +570,9 @@ export function clipLineByQuadrilateral(path, p1, p2, p3, p4) {
             nextInView = pointInQuadrilateral(point2, p1, p2, p3, p4);
             if (nextInView) {
                 const cross = getSegmenQuadrilateralIntersections(point1, point2, p1, p2, p3, p4);
-                if (cross.length !== 1) {
-                    console.error('error:只应该一个交点才对,实际有,', cross.length);
-                }
+                // if (cross.length !== 1) {
+                //     console.error('只应该一个交点才对,实际有,', cross.length);
+                // }
                 line.push(...cross)
                 continue;
             }
@@ -648,9 +648,9 @@ export function clipPolygonByQuadrilateral(path, p1, p2, p3, p4) {
     const ring = checkRing(path);
     try {
         const result = polygonClipping.intersection([MAP_TEMP_RING], [ring]);
-        if (result.length > 1) {
-            console.warn('clip polygon的结果>1:', result.length);
-        }
+        // if (result.length > 1) {
+        //     console.warn('clip polygon的结果>1:', result.length);
+        // }
         const points = [];
         const clipPath = result[0][0];
         for (let i = 0, len = clipPath.length; i < len; i++) {
@@ -665,111 +665,111 @@ export function clipPolygonByQuadrilateral(path, p1, p2, p3, p4) {
 
 }
 
-function debug(path, p1, p2, p3, p4) {
-    let canvas: HTMLCanvasElement = document.getElementById('c');
-    if (!canvas) {
-        canvas = document.createElement('canvas') as HTMLCanvasElement;
-        canvas.width = 400;
-        canvas.height = 400;
-        canvas.style.position = 'absolute';
-        canvas.style.zIndex = 1 + '';
-        canvas.style.top = '0px';
-        canvas.style.backgroundColor = 'black';
-        canvas.id = 'c';
-        document.body.appendChild(canvas);
-    }
-    const ctx = canvas.getContext('2d');
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+// function debug(path, p1, p2, p3, p4) {
+//     let canvas: HTMLCanvasElement = document.getElementById('c');
+//     if (!canvas) {
+//         canvas = document.createElement('canvas') as HTMLCanvasElement;
+//         canvas.width = 400;
+//         canvas.height = 400;
+//         canvas.style.position = 'absolute';
+//         canvas.style.zIndex = 1 + '';
+//         canvas.style.top = '0px';
+//         canvas.style.backgroundColor = 'black';
+//         canvas.id = 'c';
+//         document.body.appendChild(canvas);
+//     }
+//     const ctx = canvas.getContext('2d');
+//     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-    const points = [p1, p2, p3, p4, ...path];
-
-
-    const bbox = getDefaultBBOX();
-    pointsBBOX(points, bbox);
-    drawQuadrilateral(ctx, bbox, p1, p2, p3, p4);
-    drawPaths(ctx, bbox, [path]);
-    // drawBBOX(ctx, bbox, pathBBOX);
-    // drawExtent(ctx, bbox, extent);
-
-    return {
-        ctx,
-        bbox
-    }
-
-}
-
-function drawClipPoints(ctx, bbox, clipPoints) {
-    ctx.strokeStyle = 'yellow';
-    clipPoints.forEach(d => {
-        const points = d.map(item => {
-            return item.point;
-        })
-        const pts = toPixels(points, bbox, ctx.canvas);
-        drawPolyline(ctx, pts);
-    });
-}
-
-function drawQuadrilateral(ctx, bbox, p1, p2, p3, p4) {
-    ctx.strokeStyle = 'red';
-    const points = [p1, p2, p3, p4, p1];
-    const pts = toPixels(points, bbox, ctx.canvas);
-    drawPolyline(ctx, pts);
+//     const points = [p1, p2, p3, p4, ...path];
 
 
-}
+//     const bbox = getDefaultBBOX();
+//     pointsBBOX(points, bbox);
+//     drawQuadrilateral(ctx, bbox, p1, p2, p3, p4);
+//     drawPaths(ctx, bbox, [path]);
+//     // drawBBOX(ctx, bbox, pathBBOX);
+//     // drawExtent(ctx, bbox, extent);
 
-function drawBBOX(ctx, bbox, pathBBOX) {
-    ctx.strokeStyle = 'green';
-    const points = [];
-    const [xmin, ymin, xmax, ymax] = pathBBOX;
-    points.push(new Point(xmin, ymin));
-    points.push(new Point(xmin, ymax));
-    points.push(new Point(xmax, ymax));
-    points.push(new Point(xmax, ymin));
-    points.push(new Point(xmin, ymin));
-    const pts = toPixels(points, bbox, ctx.canvas);
-    drawPolyline(ctx, pts);
-}
+//     return {
+//         ctx,
+//         bbox
+//     }
 
-function drawPaths(ctx, bbox, paths) {
-    ctx.strokeStyle = 'green';
-    paths.forEach(path => {
-        const pts = toPixels(path, bbox, ctx.canvas);
-        pts.slice(0, pts.length - 1).forEach((pt, index) => {
-            ctx.fillStyle = 'white';
-            ctx.fillText(index, pt.x, pt.y);
-        });
-        drawPolyline(ctx, pts);
-    });
+// }
 
-}
+// function drawClipPoints(ctx, bbox, clipPoints) {
+//     ctx.strokeStyle = 'yellow';
+//     clipPoints.forEach(d => {
+//         const points = d.map(item => {
+//             return item.point;
+//         })
+//         const pts = toPixels(points, bbox, ctx.canvas);
+//         drawPolyline(ctx, pts);
+//     });
+// }
 
-function drawExtent(ctx, bbox, extent) {
-    ctx.strokeStyle = 'green';
-    const points = extent.toArray();
-    const pts = toPixels(points, bbox, ctx.canvas);
-    drawPolyline(ctx, pts);
-}
+// function drawQuadrilateral(ctx, bbox, p1, p2, p3, p4) {
+//     ctx.strokeStyle = 'red';
+//     const points = [p1, p2, p3, p4, p1];
+//     const pts = toPixels(points, bbox, ctx.canvas);
+//     drawPolyline(ctx, pts);
 
-function drawPolyline(ctx, points) {
-    ctx.beginPath();
-    points.forEach((p, index) => {
-        const { x, y } = p;
-        if (index === 0) {
-            ctx.moveTo(x, y);
-        } else {
-            ctx.lineTo(x, y)
-        }
-    });
-    ctx.stroke();
-}
 
-function toPixels(points, bbox, canvas) {
-    const [xmin, ymin, xmax, ymax] = bbox;
-    const ax = (canvas.width - 20) / (xmax - xmin), ay = (canvas.height - 20) / (ymax - ymin);
-    return points.map(p => {
-        const x = (p.x - xmin) * ax + 10;
-        const y = (canvas.height) - (p.y - ymin) * ay - 10;
-        return new Point(x, y);
-    })
-}
+// }
+
+// function drawBBOX(ctx, bbox, pathBBOX) {
+//     ctx.strokeStyle = 'green';
+//     const points = [];
+//     const [xmin, ymin, xmax, ymax] = pathBBOX;
+//     points.push(new Point(xmin, ymin));
+//     points.push(new Point(xmin, ymax));
+//     points.push(new Point(xmax, ymax));
+//     points.push(new Point(xmax, ymin));
+//     points.push(new Point(xmin, ymin));
+//     const pts = toPixels(points, bbox, ctx.canvas);
+//     drawPolyline(ctx, pts);
+// }
+
+// function drawPaths(ctx, bbox, paths) {
+//     ctx.strokeStyle = 'green';
+//     paths.forEach(path => {
+//         const pts = toPixels(path, bbox, ctx.canvas);
+//         pts.slice(0, pts.length - 1).forEach((pt, index) => {
+//             ctx.fillStyle = 'white';
+//             ctx.fillText(index, pt.x, pt.y);
+//         });
+//         drawPolyline(ctx, pts);
+//     });
+
+// }
+
+// function drawExtent(ctx, bbox, extent) {
+//     ctx.strokeStyle = 'green';
+//     const points = extent.toArray();
+//     const pts = toPixels(points, bbox, ctx.canvas);
+//     drawPolyline(ctx, pts);
+// }
+
+// function drawPolyline(ctx, points) {
+//     ctx.beginPath();
+//     points.forEach((p, index) => {
+//         const { x, y } = p;
+//         if (index === 0) {
+//             ctx.moveTo(x, y);
+//         } else {
+//             ctx.lineTo(x, y)
+//         }
+//     });
+//     ctx.stroke();
+// }
+
+// function toPixels(points, bbox, canvas) {
+//     const [xmin, ymin, xmax, ymax] = bbox;
+//     const ax = (canvas.width - 20) / (xmax - xmin), ay = (canvas.height - 20) / (ymax - ymin);
+//     return points.map(p => {
+//         const x = (p.x - xmin) * ax + 10;
+//         const y = (canvas.height) - (p.y - ymin) * ay - 10;
+//         return new Point(x, y);
+//     })
+// }

--- a/src/core/util/path.ts
+++ b/src/core/util/path.ts
@@ -1,7 +1,9 @@
 import Point from '../../geo/Point';
 import Coordinate from '../../geo/Coordinate';
 import { isNumber } from './common';
+import { bboxIntersect, getDefaultBBOX, pointsBBOX } from './bbox';
 
+const TEMP_POINT = new Point(0, 0);
 
 export function clipLine(points, bounds, round?: boolean, noCut?: boolean) {
     const parts = [];
@@ -301,3 +303,363 @@ export function getMinMaxAltitude(altitude: number | number[] | number[][]): [nu
     return [min, max];
 }
 
+function pointInSegment(p, p1, p2) {
+    const dx = p2.x - p1.x;
+    if (dx === 0) {
+        const miny = Math.min(p1.y, p2.y);
+        const maxy = Math.max(p1.y, p2.y);
+        return p.y >= miny && p.y <= maxy;
+    }
+    const dy = p2.y - p1.y;
+    const k = dy / dx;
+
+    if (k === 0) {
+        const minx = Math.min(p1.x, p2.x);
+        const maxx = Math.max(p1.x, p2.x);
+        return p.x >= minx && p.x <= maxx;
+    }
+
+    const b = p1.y - k * p1.x;
+    const y = k * p.x + b
+    return Math.abs(y - p.y) <= 0.0000001;
+}
+
+function pointLeftSegment(p, p1, p2) {
+    const x1 = p1.x, y1 = p1.y;
+    const x2 = p2.x, y2 = p2.y;
+    const x = p.x, y = p.y;
+    return (y1 - y2) * x + (x2 - x1) * y + x1 * y2 - x2 * y1 > 0;
+}
+
+function pointRightSegment(p, p1, p2) {
+    return !pointLeftSegment(p, p1, p2);
+}
+
+function pointInQuadrilateral(point, p1, p2, p3, p4) {
+    //LT-RT
+    const a = pointRightSegment(point, p1, p2) || pointInSegment(point, p1, p2);
+    //RT-RB
+    const b = pointRightSegment(point, p2, p3) || pointInSegment(point, p2, p3);
+    //RB-LB
+    const c = pointRightSegment(point, p3, p4) || pointInSegment(point, p3, p4);
+    //LB-LT
+    const d = pointRightSegment(point, p4, p1) || pointInSegment(point, p4, p1);
+    return a && b && c && d;
+}
+
+// function pathInQuadrilateral(path, p1, p2, p3, p4) {
+//     for (let i = 0, len = path.length; i < len; i++) {
+//         const p = path[i];
+//         if (!pointInQuadrilateral(p, p1, p2, p3, p4)) {
+//             return false;
+//         }
+//     }
+//     return true;
+// }
+
+// export function pathsInQuadrilateral(paths, p1, p2, p3, p4) {
+//     if (!Array.isArray(paths[0][0])) {
+//         paths = [paths];
+//     }
+//     // debug(paths, p1, p2, p3, p4);
+//     for (let i = 0, len = paths.length; i < len; i++) {
+//         if (!pathInQuadrilateral(paths[i], p1, p2, p3, p4)) {
+//             return false;
+//         }
+//     }
+//     return true;
+// }
+
+export function bboxInInQuadrilateral(bbox, p1, p2, p3, p4) {
+    const [xmin, ymin, xmax, ymax] = bbox;
+
+    TEMP_POINT.x = xmin;
+    TEMP_POINT.y = ymin;
+    if (!pointInQuadrilateral(TEMP_POINT, p1, p2, p3, p4)) {
+        return false;
+    }
+
+    TEMP_POINT.x = xmin;
+    TEMP_POINT.y = ymax;
+    if (!pointInQuadrilateral(TEMP_POINT, p1, p2, p3, p4)) {
+        return false;
+    }
+
+    TEMP_POINT.x = xmax;
+    TEMP_POINT.y = ymax;
+    if (!pointInQuadrilateral(TEMP_POINT, p1, p2, p3, p4)) {
+        return false;
+    }
+
+    TEMP_POINT.x = xmax;
+    TEMP_POINT.y = ymin;
+    if (!pointInQuadrilateral(TEMP_POINT, p1, p2, p3, p4)) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * 
+ * @param p1 
+ * @param p2 
+ * @param p3 
+ * @param p4 
+ * @returns 
+ */
+export function lineSegmentIntersection(p1, p2, p3, p4) {
+    const dx1 = p2.x - p1.x, dy1 = p2.y - p1.y;
+    const dx2 = p4.x - p3.x, dy2 = p4.y - p3.y;
+    if (dx1 === 0 && dx2 === 0) {
+        return null;
+    }
+    if (dy1 === 0 && dy2 === 0) {
+        return null;
+    }
+
+    const k1 = dy1 / dx1;
+    const k2 = dy2 / dx2;
+
+    const b1 = p1.y - k1 * p1.x;
+    const b2 = p3.y - k2 * p3.x;
+
+    let x, y;
+
+    if (dx1 === 0) {
+        x = p1.x;
+        y = k2 * x + b2;
+    } else if (dx2 === 0) {
+        x = p3.x;
+        y = k1 * x + b1;
+    } else {
+        x = (b2 - b1) / (k1 - k2);
+        y = k1 * x + b1;
+    }
+
+    if (x < Math.min(p1.x, p2.x) || x > Math.max(p1.x, p2.x)) {
+        return;
+    }
+    if (x < Math.min(p3.x, p4.x) || x > Math.max(p3.x, p4.x)) {
+        return;
+    }
+    if (y < Math.min(p1.y, p2.y) || y > Math.max(p1.y, p2.y)) {
+        return;
+    }
+    if (y < Math.min(p3.y, p4.y) || y > Math.max(p3.y, p4.y)) {
+        return;
+    }
+    return new Point(x, y);
+    // TEMP_POINT.x = x;
+    // TEMP_POINT.y = y;
+    // if (pointInSegment(TEMP_POINT, p1, p2) && pointInSegment(TEMP_POINT, p3, p4)) {
+    //     return new Point(x, y);
+    // }
+    // return null;
+}
+
+
+function getSegmenIntersections(currentPoint, nextPoint, p1, p2, p3, p4) {
+    const a = lineSegmentIntersection(currentPoint, nextPoint, p1, p2);
+    const b = lineSegmentIntersection(currentPoint, nextPoint, p2, p3);
+    const c = lineSegmentIntersection(currentPoint, nextPoint, p3, p4);
+    const d = lineSegmentIntersection(currentPoint, nextPoint, p4, p1);
+    const points = [];
+    if (a) {
+        points.push(a);
+        a.segment = {
+            index: 1,
+            points: [p1, p2]
+        }
+    }
+    if (b) {
+        points.push(b);
+        b.segment = {
+            index: 2,
+            points: [p2, p3]
+        }
+    }
+    if (c) {
+        points.push(c);
+        c.segment = {
+            index: 3,
+            points: [p3, p4]
+        }
+    }
+    if (d) {
+        points.push(d);
+        d.segment = {
+            index: 4,
+            points: [p4, p1]
+        }
+    }
+    if (points.length < 2) {
+        return points
+    }
+    const [c1, c2] = points;
+    const distance1 = c1.distanceTo(currentPoint);
+    const distance2 = c2.distanceTo(currentPoint);
+    if (distance1 < distance2) {
+        return [c1, c2];
+    }
+    return [c2, c1];
+
+}
+
+export function clipLineByQuadrilateral(path, p1, p2, p3, p4) {
+    debug(path, p1, p2, p3, p4);
+    const result = [];
+    let line = [];
+    let nextInView;
+    for (let i = 0, len = path.length; i < len; i++) {
+        const point1 = path[i], point2 = path[i + 1], point3 = path[i + 2];
+        let inView;
+        if (i === 0) {
+            inView = pointInQuadrilateral(point1, p1, p2, p3, p4);
+        } else {
+            inView = nextInView;
+        }
+        // console.log(i, inView);
+        if (inView) {
+            line.push(point1);
+            if (!point2) {
+                continue;
+            }
+            nextInView = pointInQuadrilateral(point2, p1, p2, p3, p4);
+            if (nextInView) {
+                continue;
+            }
+            const cross = getSegmenIntersections(point1, point2, p1, p2, p3, p4);
+            line.push(...cross);
+            // console.log(i);
+            if (point3) {
+                if (!pointInQuadrilateral(point3, p1, p2, p3, p4)) {
+                    // console.log(i);
+                    const cross1 = getSegmenIntersections(point2, point3, p1, p2, p3, p4);
+                    console.log(cross1, i);
+                    // if (cross.length > 0) {
+                    //     console.log(i);
+                    //     line.push(cross[0].segment[1]);
+                    // }
+                }
+            }
+
+        } else {
+            if (!point2) {
+                continue;
+            }
+            nextInView = pointInQuadrilateral(point2, p1, p2, p3, p4);
+            if (!nextInView) {
+                const cross = getSegmenIntersections(point1, point2, p1, p2, p3, p4);
+                if (cross.length) {
+                    line.push(...cross);
+                    continue;
+                }
+                if (line.length > 1) {
+                    result.push(line);
+                    line = [];
+                }
+                continue;
+            }
+            const cross = getSegmenIntersections(point1, point2, p1, p2, p3, p4);
+            line.push(...cross)
+        }
+    }
+    if (line.length > 1) {
+        result.push(line);
+    }
+    result.forEach((path) => {
+        path.forEach((p, index) => {
+            path[index] = { point: p };
+        });
+    });
+    return result;
+}
+
+function debug(path, p1, p2, p3, p4) {
+    let canvas: HTMLCanvasElement = document.getElementById('c');
+    if (!canvas) {
+        canvas = document.createElement('canvas') as HTMLCanvasElement;
+        canvas.width = 400;
+        canvas.height = 400;
+        canvas.style.position = 'absolute';
+        canvas.style.zIndex = 1 + '';
+        canvas.style.top = '0px';
+        canvas.style.backgroundColor = 'black';
+        canvas.id = 'c';
+        document.body.appendChild(canvas);
+    }
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    const points = [p1, p2, p3, p4, ...path];
+
+
+    const bbox = getDefaultBBOX();
+    pointsBBOX(points, bbox);
+    drawQuadrilateral(ctx, bbox, p1, p2, p3, p4);
+    drawPaths(ctx, bbox, [path]);
+    // drawBBOX(ctx, bbox, pathBBOX);
+    // drawExtent(ctx, bbox, extent);
+
+}
+
+function drawQuadrilateral(ctx, bbox, p1, p2, p3, p4) {
+    ctx.strokeStyle = 'red';
+    const points = [p1, p2, p3, p4, p1];
+    const pixel1 = toPixels(points, bbox, ctx.canvas);
+    drawPolyline(ctx, pixel1);
+
+}
+
+function drawBBOX(ctx, bbox, pathBBOX) {
+    ctx.strokeStyle = 'green';
+    const points = [];
+    const [xmin, ymin, xmax, ymax] = pathBBOX;
+    points.push(new Point(xmin, ymin));
+    points.push(new Point(xmin, ymax));
+    points.push(new Point(xmax, ymax));
+    points.push(new Point(xmax, ymin));
+    points.push(new Point(xmin, ymin));
+    const pixel1 = toPixels(points, bbox, ctx.canvas);
+    drawPolyline(ctx, pixel1);
+}
+
+function drawPaths(ctx, bbox, paths) {
+    ctx.strokeStyle = 'green';
+    paths.forEach(path => {
+        const pixel1 = toPixels(path, bbox, ctx.canvas);
+        drawPolyline(ctx, pixel1);
+    });
+
+}
+
+function drawExtent(ctx, bbox, extent) {
+    ctx.strokeStyle = 'green';
+    const points = extent.toArray();
+    const pixel1 = toPixels(points, bbox, ctx.canvas);
+    drawPolyline(ctx, pixel1);
+}
+
+function drawPolyline(ctx, points) {
+    ctx.beginPath();
+    points.forEach((p, index) => {
+        const { x, y } = p;
+        if (index === 0) {
+            ctx.moveTo(x, y);
+        } else {
+            ctx.lineTo(x, y)
+        }
+    });
+    ctx.stroke();
+}
+
+function toPixels(points, bbox, canvas) {
+    const [xmin, ymin, xmax, ymax] = bbox;
+    const ax = (canvas.width - 20) / (xmax - xmin), ay = (canvas.height - 20) / (ymax - ymin);
+    return points.map(p => {
+        const x = (p.x - xmin) * ax + 10;
+        const y = (canvas.height) - (p.y - ymin) * ay - 10;
+        return new Point(x, y);
+    })
+}

--- a/src/core/util/path.ts
+++ b/src/core/util/path.ts
@@ -325,7 +325,7 @@ function pointInSegment(p: Point, p1: Point, p2: Point) {
     if (dx === 0) {
         const miny = Math.min(p1.y, p2.y);
         const maxy = Math.max(p1.y, p2.y);
-        return p.y >= miny && p.y <= maxy;
+        return p.y >= miny && p.y <= maxy && p.x === p1.x;
     }
     const dy = p2.y - p1.y;
     const k = dy / dx;
@@ -333,7 +333,7 @@ function pointInSegment(p: Point, p1: Point, p2: Point) {
     if (k === 0) {
         const minx = Math.min(p1.x, p2.x);
         const maxx = Math.max(p1.x, p2.x);
-        return p.x >= minx && p.x <= maxx;
+        return p.x >= minx && p.x <= maxx && p.y === p1.y;
     }
 
     const b = p1.y - k * p1.x;

--- a/src/core/util/path.ts
+++ b/src/core/util/path.ts
@@ -580,13 +580,15 @@ export function clipLineByQuadrilateral(path, p1, p2, p3, p4) {
             const cross = getSegmenQuadrilateralIntersections(point1, point2, p1, p2, p3, p4);
             if (cross.length) {
                 line.push(...cross);
-                if (point3 && pointInQuadrilateral(point3, p1, p2, p3, p4)) {
+                if (point3) {
                     const cross1 = getSegmenQuadrilateralIntersections(point2, point3, p1, p2, p3, p4);
-                    const p = cross1[0];
-                    if (!hasSameEdge(p, cross)) {
-                        line.push({
-                            point: p.edge[0]
-                        });
+                    if (cross1.length) {
+                        const p = cross1[0];
+                        if (!hasSameEdge(p, cross)) {
+                            line.push({
+                                point: p.edge[0]
+                            });
+                        }
                     }
                 }
                 continue;
@@ -713,6 +715,7 @@ function drawQuadrilateral(ctx, bbox, p1, p2, p3, p4) {
     const pts = toPixels(points, bbox, ctx.canvas);
     drawPolyline(ctx, pts);
 
+
 }
 
 function drawBBOX(ctx, bbox, pathBBOX) {
@@ -732,6 +735,10 @@ function drawPaths(ctx, bbox, paths) {
     ctx.strokeStyle = 'green';
     paths.forEach(path => {
         const pts = toPixels(path, bbox, ctx.canvas);
+        pts.slice(0, pts.length - 1).forEach((pt, index) => {
+            ctx.fillStyle = 'white';
+            ctx.fillText(index, pt.x, pt.y);
+        });
         drawPolyline(ctx, pts);
     });
 

--- a/src/core/util/path.ts
+++ b/src/core/util/path.ts
@@ -780,10 +780,14 @@ export function clipPolygonByQuadrilateral(path: Array<Point>, p1: Point, p2: Po
     try {
         const ring = checkRing(path);
         const result = polygonClipping.intersection([MAP_TEMP_RING], [ring]);
-        const points = [];
+        if (!result || result.length > 1) {
+            return null;
+        }
         if (!result[0] || !result[0][0]) {
             return null;
         }
+        const points = [];
+
         const clipPath = result[0][0];
         for (let i = 0, len = clipPath.length; i < len; i++) {
             const p = clipPath[i];

--- a/src/geometry/Path.ts
+++ b/src/geometry/Path.ts
@@ -23,6 +23,7 @@ const options: PathOptionsType = {
     'smoothness': false,
     'enableClip': true,
     'enableSimplify': true,
+    'strictClipMode': false,
     'simplifyTolerance': 2,
     'symbol': {
         'lineColor': '#000',
@@ -486,6 +487,7 @@ export default Path;
 export type PathOptionsType = GeometryOptionsType & {
     'smoothness'?: boolean;
     'enableClip'?: boolean;
+    'strictClipMode'?: boolean;
     'enableSimplify'?: boolean;
     'simplifyTolerance'?: number;
     'symbol'?: FillSymbol | LineSymbol;

--- a/src/renderer/geometry/Painter.ts
+++ b/src/renderer/geometry/Painter.ts
@@ -508,7 +508,7 @@ class Painter extends Class {
         if (pitched) {
             const glRes = map.getGLRes();
             let { xmin, ymin, xmax, ymax } = map.getContainerExtent();
-            const offset = 10;
+            const offset = 0;
             xmin += offset;
             xmax -= offset;
             ymax -= offset;

--- a/src/renderer/geometry/Painter.ts
+++ b/src/renderer/geometry/Painter.ts
@@ -508,7 +508,7 @@ class Painter extends Class {
         if (pitched) {
             const glRes = map.getGLRes();
             let { xmin, ymin, xmax, ymax } = map.getContainerExtent();
-            const offset = 0;
+            const offset = 4;
             xmin += offset;
             xmax -= offset;
             ymax -= offset;
@@ -584,6 +584,7 @@ class Painter extends Class {
         } else if (geometry.getJSONType() === 'LineString' && !smoothness) {
             // clip the line string to draw less and improve performance
             if (!Array.isArray(points[0])) {
+                // clipPoints = clipLine(points, TEMP_CLIP_EXTENT0, false, !!smoothness);
                 if (pitched) {
                     clipPoints = clipLineByQuadrilateral(points, p1, p2, p3, p4);
                 } else {

--- a/src/renderer/geometry/Painter.ts
+++ b/src/renderer/geometry/Painter.ts
@@ -582,10 +582,8 @@ class Painter extends Class {
             if (!Array.isArray(points[0])) {
                 if (strictClipEnable) {
                     clipPoints = clipPolygonByQuadrilateral(points, p1, p2, p3, p4);
-                    if (!clipPoints) {
-                        clipPoints = clipPolygon(points, TEMP_CLIP_EXTENT0);
-                    }
-                } else {
+                }
+                if ((!strictClipEnable || !clipPoints)) {
                     clipPoints = clipPolygon(points, TEMP_CLIP_EXTENT0);
                 }
             } else {
@@ -594,10 +592,8 @@ class Painter extends Class {
                     let part;
                     if (strictClipEnable) {
                         part = clipPolygonByQuadrilateral(points[i] as unknown as Array<Point>, p1, p2, p3, p4);
-                        if (!part) {
-                            part = clipPolygon(points[i], TEMP_CLIP_EXTENT0);
-                        }
-                    } else {
+                    }
+                    if ((!strictClipEnable || !part)) {
                         part = clipPolygon(points[i], TEMP_CLIP_EXTENT0);
                     }
                     if (part.length) {

--- a/src/renderer/geometry/Painter.ts
+++ b/src/renderer/geometry/Painter.ts
@@ -515,19 +515,24 @@ class Painter extends Class {
             xmin -= offset;
             xmax += offset;
             ymax += offset;
+            ymin += 0;
             const p = new Point(xmin, ymin);
+            //LT
             p1 = map['_containerPointToPointAtRes'](p, glRes);
 
             p.x = xmax;
             p.y = ymin;
+            //RT
             p2 = map['_containerPointToPointAtRes'](p, glRes);
 
             p.x = xmax;
             p.y = ymax;
+            //BR
             p3 = map['_containerPointToPointAtRes'](p, glRes);
 
             p.x = xmin;
             p.y = ymax;
+            //BL
             p4 = map['_containerPointToPointAtRes'](p, glRes);
         }
         let clipPoints = points;
@@ -535,6 +540,7 @@ class Painter extends Class {
         if (pitched) {
             const bbox = getDefaultBBOX();
             pointsBBOX(points, bbox);
+            // paths in current view
             if (bboxInInQuadrilateral(bbox, p1, p2, p3, p4)) {
                 return {
                     points: clipPoints,
@@ -587,7 +593,7 @@ class Painter extends Class {
                 for (let i = 0; i < points.length; i++) {
                     let part;
                     if (strictClipEnable) {
-                        part = clipPolygonByQuadrilateral(points[i], p1, p2, p3, p4);
+                        part = clipPolygonByQuadrilateral(points[i] as unknown as Array<Point>, p1, p2, p3, p4);
                         if (!part) {
                             part = clipPolygon(points[i], TEMP_CLIP_EXTENT0);
                         }

--- a/src/renderer/geometry/Painter.ts
+++ b/src/renderer/geometry/Painter.ts
@@ -515,7 +515,7 @@ class Painter extends Class {
             xmin -= offset;
             xmax += offset;
             ymax += offset;
-            ymin += 0;
+            ymin -= offset;
             const p = new Point(xmin, ymin);
             //LT
             p1 = map['_containerPointToPointAtRes'](p, glRes);


### PR DESCRIPTION
fix https://github.com/maptalks/maptalks.js/issues/1439

![%1KUU`EPZIO 4{V1ISV`K)8](https://github.com/user-attachments/assets/000209a1-e0d7-4769-a1f0-1cdbe10646d9)


- 当path开启严格剪裁模式时才生效，默认是关闭的，保守点，当验证没有问题后再默认开启

```js
   const line = new maptalks.LineString([
                [118.83815604508771, 32.2050187055254],

                [118.89524227133437, 31.837171843218112]
            ], {
                strictClipMode: true
            });


```