### PR TITLE
Fix: add types to parameters

### DIFF
--- a/packages/map/src/geometry/Marker.ts
+++ b/packages/map/src/geometry/Marker.ts
@@ -89,7 +89,7 @@ export class Marker extends CenterMixin(Geometry) {
         });
     }
 
-    setSymbol(symbol: AnyMarkerSymbol): this {
+    setSymbol(symbol: AnyMarkerSymbol | Array<AnyMarkerSymbol>): this {
         delete this._fixedExtent;
         return super.setSymbol.call(this, symbol);
     }

--- a/packages/map/src/geometry/ext/Geometry.InfoWindow.ts
+++ b/packages/map/src/geometry/ext/Geometry.InfoWindow.ts
@@ -35,7 +35,7 @@ Geometry.include(/** @lends Geometry.prototype */ {
      *     content  : '<div style="color:#f00">This is content of the InfoWindow</div>'
      * });
      */
-    setInfoWindow(options: InfoWindowOptionsType) {
+    setInfoWindow(options: InfoWindowOptionsType | InfoWindow) {
         this.removeInfoWindow();
         if (options instanceof InfoWindow) {
             this._infoWindow = options;


### PR DESCRIPTION
In the marker methods, I came into a type error.

One symbol can be specified when using the "setSymbol" method, but an array of symbols can be specified when creating a marker. There doesn't seem to be any justification for restricting the parameters that the function can take in because it utilizes a parent method that compares the type to an array.

This is also true for the "setInfoWindow" method, which verifies that the obtained argument is of the "InfoWindow" type.