### PR TITLE
deprecated Class.setOptions

### DIFF
--- a/packages/maptalks/src/core/Class.ts
+++ b/packages/maptalks/src/core/Class.ts
@@ -57,10 +57,10 @@ class Class {
      * @param options - options to set
      */
     constructor(options?: ClassOptions) {
-        if (!this || !this.setOptions) {
+        if (!this || !this._setOptions) {
             throw new Error('Class instance is being created without "new" operator.');
         }
-        this.setOptions(options);
+        this._setOptions(options);
         this.callInitHooks();
         this._isUpdatingOptions = false;
     }
@@ -107,7 +107,7 @@ class Class {
      * Merges options with the default options of the object.
      * @param options - options to set
      */
-    setOptions(options: ClassOptions) {
+    _setOptions(options: ClassOptions) {
         if (!this.hasOwnProperty('options') || isNil(this.options)) {
             this.options = this.options ? Object.create(this.options) : {};
         }
@@ -118,6 +118,11 @@ class Class {
             this.options[i] = options[i];
         }
         return this;
+    }
+
+    setOptions(options: ClassOptions) {
+        console.warn('setOptions(options) It is a private method and deprecated, please use _setOptions(options) instead.');
+        return this._setOptions(options);
     }
 
     /**

--- a/packages/maptalks/src/core/Class.ts
+++ b/packages/maptalks/src/core/Class.ts
@@ -121,7 +121,7 @@ class Class {
     }
 
     setOptions(options: ClassOptions) {
-        console.warn('setOptions(options) It is a private method and deprecated, please use _setOptions(options) instead.');
+        console.warn('setOptions(options) It is a private method and deprecated, please use _setOptions(options) instead. If you want to update options, please use config(options) instead.');
         return this._setOptions(options);
     }
 

--- a/packages/maptalks/src/geometry/Geometry.ts
+++ b/packages/maptalks/src/geometry/Geometry.ts
@@ -1331,7 +1331,7 @@ export class Geometry extends JSONAble(Eventable(Handlerable(Class))) {
         delete opts['symbol'];
         delete opts['id'];
         delete opts['properties'];
-        this.setOptions(opts);
+        this._setOptions(opts);
         if (symbol) {
             this.setSymbol(symbol);
         }

--- a/packages/maptalks/src/geometry/ext/Geometry.InfoWindow.ts
+++ b/packages/maptalks/src/geometry/ext/Geometry.InfoWindow.ts
@@ -45,7 +45,7 @@ Geometry.include(/** @lends Geometry.prototype */ {
         }
         this._infoWinOptions = extend({}, options);
         if (this._infoWindow) {
-            this._infoWindow.setOptions(options);
+            this._infoWindow._setOptions(options);
         } else if (this.getMap()) {
             this._bindInfoWindow();
         }

--- a/packages/maptalks/src/layer/tile/WMSTileLayer.ts
+++ b/packages/maptalks/src/layer/tile/WMSTileLayer.ts
@@ -68,7 +68,7 @@ class WMSTileLayer extends TileLayer {
             wmsExcludeParams = extend({}, this.options);
         }
         this.wmsParams = extend({} as WMSTileLayerOptionsType, defaultWmsParams);
-        this.setOptions(options);
+        this._setOptions(options);
         this.setZIndex(options.zIndex);
         if (!Browser.proxy) {
             this._optionsHook(options);

--- a/packages/maptalks/src/ui/Menuable.ts
+++ b/packages/maptalks/src/ui/Menuable.ts
@@ -65,7 +65,7 @@ const Menuable = {
         this._menuOptions = options;
 
         if (this._menu) {
-            this._menu.setOptions(options);
+            this._menu._setOptions(options);
         } else {
             this.on('contextmenu', this._defaultOpenMenu, this);
         }


### PR DESCRIPTION
fix #2530 

理由：

- 已经有太多的同学被这个方法误导了，这个方法显然应该是是个私有方法
- 当用户侧访问这个方法直接给警告
- 所有子类访问时可以访问`_setOptions`方法,包括插件开发等
