### PR TITLE
feat:VectorTileLayer support config tile cache max size

### DIFF
--- a/packages/vt/src/layer/layer/VectorTileLayer.ts
+++ b/packages/vt/src/layer/layer/VectorTileLayer.ts
@@ -2021,7 +2021,7 @@ export type VectorTileLayerOptionsType = {
   disableAltitudeWarning?: boolean,
   loadTileErrorLog?: boolean,
   loadTileErrorLogIgnoreCodes?: Array<number>;
-  loadTileCachMaxSize?: number;
+  loadTileCachMaxSize?: number;//unit is MB
   loadTileCacheLog?: boolean
 } & TileLayerOptionsType;
 

--- a/packages/vt/src/layer/layer/VectorTileLayer.ts
+++ b/packages/vt/src/layer/layer/VectorTileLayer.ts
@@ -91,7 +91,7 @@ const defaultOptions: VectorTileLayerOptionsType = {
   disableAltitudeWarning: false,
   loadTileErrorLog: true,
   loadTileErrorLogIgnoreCodes: [404, 204],
-  loadTileCachMaxSize: 0,
+  loadTileCachMaxSize: 0,//MB, 0 no limit
   loadTileCacheLog: true
 };
 

--- a/packages/vt/src/layer/layer/VectorTileLayer.ts
+++ b/packages/vt/src/layer/layer/VectorTileLayer.ts
@@ -90,7 +90,9 @@ const defaultOptions: VectorTileLayerOptionsType = {
   altitudePropertyName: null,
   disableAltitudeWarning: false,
   loadTileErrorLog: true,
-  loadTileErrorLogIgnoreCodes: [404, 204]
+  loadTileErrorLogIgnoreCodes: [404, 204],
+  loadTileCachMaxSize: 0,
+  loadTileCacheLog: true
 };
 
 /**
@@ -2019,6 +2021,8 @@ export type VectorTileLayerOptionsType = {
   disableAltitudeWarning?: boolean,
   loadTileErrorLog?: boolean,
   loadTileErrorLogIgnoreCodes?: Array<number>;
+  loadTileCachMaxSize?: number;
+  loadTileCacheLog?: boolean
 } & TileLayerOptionsType;
 
 export type AsyncFeatureQueryOptions = {

--- a/packages/vt/src/layer/renderer/VectorTileLayerRenderer.js
+++ b/packages/vt/src/layer/renderer/VectorTileLayerRenderer.js
@@ -554,6 +554,8 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
             const disableAltitudeWarning = this.layer.options['disableAltitudeWarning'];
             const loadTileErrorLog = this.layer.options.loadTileErrorLog;
             const loadTileErrorLogIgnoreCodes = this.layer.options.loadTileErrorLogIgnoreCodes;
+            const loadTileCachMaxSize = this.layer.options.loadTileCachMaxSize;
+            const loadTileCacheLog = this.layer.options.loadTileCacheLog;
             const loadTileOpitons = {
                 tileInfo: {
                     res: tileInfo.res,
@@ -568,6 +570,8 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
                 disableAltitudeWarning,
                 loadTileErrorLog,
                 loadTileErrorLogIgnoreCodes,
+                loadTileCachMaxSize,
+                loadTileCacheLog,
                 altitudePropertyName,
                 zScale: this._zScale,
                 centimeterToPoint,

--- a/packages/vt/src/worker/layer/VectorTileLayerWorker.js
+++ b/packages/vt/src/worker/layer/VectorTileLayerWorker.js
@@ -5,7 +5,7 @@ import Ajax from '../util/Ajax';
 import { isNil, hasOwn, isString } from '../../common/Util';
 import { PROP_OMBB } from '../../common/Constant';
 import { projectOMBB } from '../builder/Ombb.js';
-
+import { calArrayBufferSize, isNumber } from '../util/index';
 const ALTITUDE_ERRORS = {
     'MISSING_ALTITUDE_ELEMENT': 2,
 };
@@ -49,6 +49,7 @@ export default class VectorTileLayerWorker extends LayerWorker {
         }
         fetchOptions.referrer = context.referrer;
         fetchOptions.errorLog = context.loadTileErrorLog;
+        const { loadTileCachMaxSize, loadTileCacheLog, } = context;
         return Ajax.getArrayBuffer(url, fetchOptions, (err, response) => {
             if (!this._cache) {
                 // removed
@@ -59,7 +60,19 @@ export default class VectorTileLayerWorker extends LayerWorker {
                     this._cache.add(url, { err, data: response && response.data, cacheIndex: context.workerCacheIndex });
                 }
             } else if (response && response.data) {
-                this._cache.add(url, { err: null, data: response.data, cacheIndex: context.workerCacheIndex });
+                let needCache = true;
+                if (isNumber(loadTileCachMaxSize) && loadTileCachMaxSize > 0) {
+                    const bufferSize = calArrayBufferSize(response.data);
+                    if (bufferSize > loadTileCachMaxSize) {
+                        needCache = false;
+                        if (loadTileCacheLog) {
+                            console.warn(`loadTileCachMaxSize exceeded: ${bufferSize} > ${loadTileCachMaxSize},the url: ${url} will not be cached.`);
+                        }
+                    }
+                }
+                if (needCache) {
+                    this._cache.add(url, { err: null, data: response.data, cacheIndex: context.workerCacheIndex });
+                }
             }
 
             this._readTile(url, altitudePropertyName, disableAltitudeWarning, err, response && response.data, cb);

--- a/packages/vt/src/worker/layer/VectorTileLayerWorker.js
+++ b/packages/vt/src/worker/layer/VectorTileLayerWorker.js
@@ -67,7 +67,7 @@ export default class VectorTileLayerWorker extends LayerWorker {
                     if (bufferSize > loadTileCachMaxSize) {
                         needCache = false;
                         if (loadTileCacheLog) {
-                            console.warn(`loadTileCachMaxSize exceeded: ${bufferSize} > ${loadTileCachMaxSize},the url: ${url} will not be cached.`);
+                            console.warn(`url:${url},loadTileCachMaxSize exceeded: ${bufferSize} > ${loadTileCachMaxSize},the tile will not be cached.`);
                         }
                     }
                 }

--- a/packages/vt/src/worker/layer/VectorTileLayerWorker.js
+++ b/packages/vt/src/worker/layer/VectorTileLayerWorker.js
@@ -6,6 +6,7 @@ import { isNil, hasOwn, isString } from '../../common/Util';
 import { PROP_OMBB } from '../../common/Constant';
 import { projectOMBB } from '../builder/Ombb.js';
 import { calArrayBufferSize, isNumber } from '../util/index';
+
 const ALTITUDE_ERRORS = {
     'MISSING_ALTITUDE_ELEMENT': 2,
 };

--- a/packages/vt/src/worker/util/index.js
+++ b/packages/vt/src/worker/util/index.js
@@ -1,4 +1,4 @@
-//return mb size of arraybuffer
+//return MB size of arraybuffer
 export function calArrayBufferSize(buffer) {
     if (!buffer) {
         return 0;

--- a/packages/vt/src/worker/util/index.js
+++ b/packages/vt/src/worker/util/index.js
@@ -1,0 +1,14 @@
+//return mb size of arraybuffer
+export function calArrayBufferSize(buffer) {
+    if (!buffer) {
+        return 0;
+    }
+    if (!(buffer instanceof ArrayBuffer)) {
+        return 0;
+    }
+    return buffer.byteLength / 1048576;
+}
+
+export function isNumber(val) {
+    return (typeof val === 'number') && !isNaN(val);
+}


### PR DESCRIPTION
fix https://github.com/maptalks/issues/issues/846

```js
  const layer = new maptalks.VectorTileLayer('layer',
            {
                loadTileErrorLog: false,
                loadTileErrorLogIgnoreCodes: [204],
                loadTileCachMaxSize:5,// MB
                loadTileCacheLog:false,

            }
        )


```