### PR TITLE
feat:Optimize worker data transmission for VT feature geometry

### DIFF
--- a/packages/vt/src/common/Util.js
+++ b/packages/vt/src/common/Util.js
@@ -223,7 +223,11 @@ export function decodeJSON(uint8Array) {
     }
 }
 
-export function wrapVTFeatureGeometryInfo(tileCacheImage, features) {
+export function wrapVTFeatureGeometryInfo(layerFeatueValue, tileCacheImage, features) {
+    // layer features is 0 or false
+    if (!layerFeatueValue) {
+        return;
+    }
     if (!tileCacheImage || !features || !Array.isArray(features)) {
         return;
     }
@@ -250,7 +254,13 @@ export function wrapVTFeatureGeometryInfo(tileCacheImage, features) {
                 if (featureJSON && isObj) {
                     // feature.properties = featureJSON.properties;
                     //把geometry信息补起来
-                    feature.geometry = featureJSON.geometry;
+                    if (!feature.geometry || !feature.geometry.coordinates) {
+                        feature.geometry = featureJSON.geometry;
+                        feature.geometry.isMVTCoordinates = true;
+                        if (!feature.geometry.type) {
+                            feature.geometry.type = featureJSON.type;
+                        }
+                    }
                 }
             }
         }

--- a/packages/vt/src/common/Util.js
+++ b/packages/vt/src/common/Util.js
@@ -223,12 +223,12 @@ export function decodeJSON(uint8Array) {
     }
 }
 
-export function wrapVTFeatureGeometryInfo(layerFeatueValue, tileCacheImage, features) {
+export function wrapVTFeatureGeometryInfo(layerOptionsFeatures, tileCacheImage, dataList) {
     // layer features is 0 or false
-    if (!layerFeatueValue) {
+    if (!layerOptionsFeatures) {
         return;
     }
-    if (!tileCacheImage || !features || !Array.isArray(features)) {
+    if (!tileCacheImage || !dataList || !Array.isArray(dataList)) {
         return;
     }
     const image = tileCacheImage;
@@ -239,31 +239,28 @@ export function wrapVTFeatureGeometryInfo(layerFeatueValue, tileCacheImage, feat
         delete image.featuresTypeArray;
     }
     const featuresFullJSON = image.featuresFullJSON;
-
-    const linkTo = (dataList) => {
+    if (featuresFullJSON) {
         dataList = dataList || [];
-        if (featuresFullJSON) {
-            for (let i = 0, len = dataList.length; i < len; i++) {
-                const feature = dataList[i].feature;
-                let featureId = feature;
-                const isObj = isObject(featureId);
-                if (isObj) {
-                    featureId = featureId.id;
-                }
-                const featureJSON = featuresFullJSON[featureId];
-                if (featureJSON && isObj) {
-                    // feature.properties = featureJSON.properties;
-                    //把geometry信息补起来
-                    if (!feature.geometry || !feature.geometry.coordinates) {
-                        feature.geometry = featureJSON.geometry;
-                        feature.geometry.isMVTCoordinates = true;
-                        if (!feature.geometry.type) {
-                            feature.geometry.type = featureJSON.type;
-                        }
+        for (let i = 0, len = dataList.length; i < len; i++) {
+            const feature = dataList[i].feature;
+            let featureId = feature;
+            const isObj = isObject(featureId);
+            if (isObj) {
+                featureId = featureId.id;
+            }
+            const featureJSON = featuresFullJSON[featureId];
+            if (featureJSON && isObj) {
+                // feature.properties = featureJSON.properties;
+                //把geometry信息补起来
+                if (!feature.geometry || !feature.geometry.coordinates) {
+                    feature.geometry = featureJSON.geometry;
+                    feature.geometry.isMVTCoordinates = true;
+                    if (!feature.geometry.type) {
+                        feature.geometry.type = featureJSON.type;
                     }
                 }
             }
         }
     }
-    linkTo(features);
+
 }

--- a/packages/vt/src/layer/layer/GeojsonVectorTileLayer.ts
+++ b/packages/vt/src/layer/layer/GeojsonVectorTileLayer.ts
@@ -9,7 +9,7 @@ import VectorTileLayer, { VectorTileLayerOptionsType } from "./VectorTileLayer";
 const options = {
     //feature data to return from worker
     //for geojson layer, only need to return id of features
-    features: true,
+    features: "id",
     tileBuffer: 64,
     extent: 8192,
     pyramidMode: 1,

--- a/packages/vt/src/layer/layer/GeojsonVectorTileLayer.ts
+++ b/packages/vt/src/layer/layer/GeojsonVectorTileLayer.ts
@@ -9,7 +9,7 @@ import VectorTileLayer, { VectorTileLayerOptionsType } from "./VectorTileLayer";
 const options = {
     //feature data to return from worker
     //for geojson layer, only need to return id of features
-    features: "id",
+    features: true,
     tileBuffer: 64,
     extent: 8192,
     pyramidMode: 1,

--- a/packages/vt/src/layer/layer/VectorTileLayer.ts
+++ b/packages/vt/src/layer/layer/VectorTileLayer.ts
@@ -1642,13 +1642,15 @@ class VectorTileLayer extends maptalks.TileLayer {
             point.y * dpr,
             options
         );
-        if (
-            (this.options as any)["features"] &&
-            (this.options as any)["features"] !== "id"
-        ) {
-            // 将瓦片坐标转成经纬度坐标
-            results = this._convertPickedFeature(results);
-        }
+        // if (
+        //     (this.options as any)["features"] &&
+        //     (this.options as any)["features"] !== "id"
+        // ) {
+        //     // 将瓦片坐标转成经纬度坐标
+        //     results = this._convertPickedFeature(results);
+        // }
+        //always _convertPickedFeature
+        results = this._convertPickedFeature(results);
         if (options && options.filter) {
             return results.filter(g => options.filter(g));
         } else {
@@ -1680,13 +1682,15 @@ class VectorTileLayer extends maptalks.TileLayer {
                 const type = pick.data.feature.type;
                 pick.data.feature.type = "Feature";
                 // pick.data.feature.type = getFeatureType(pick.data.feature);
-                pick.data.feature.geometry = this._convertGeometry(
-                    type,
-                    geometry,
-                    nw,
-                    extent,
-                    res
-                );
+                if (geometry.isMVTCoordinates) {
+                    pick.data.feature.geometry = this._convertGeometry(
+                        geometry.type || type,
+                        geometry,
+                        nw,
+                        extent,
+                        res
+                    );
+                }
                 // pick.data.feature.geometry = this._convertGeometryCoords(geometry, nw, extent, res);
             }
         }

--- a/packages/vt/src/layer/layer/VectorTileLayer.ts
+++ b/packages/vt/src/layer/layer/VectorTileLayer.ts
@@ -670,15 +670,13 @@ class VectorTileLayer extends maptalks.TileLayer {
             if (!feature || !tile || !geometry) {
                 continue;
             }
-            if (geometry.isMVTCoordinates) {
-                const { x, y, res, extent } = tile;
-                if (x !== tempX || y !== tempY || res !== tempRes) {
-                    tempNW = tileConfig.getTilePointNW(x, y, res);
-                }
-                const type = feature.type;
-                const geo = this._convertGeometry(geometry.type || type, geometry, tempNW, extent, res);
-                feature.geometry = geo;
+            const { x, y, res, extent } = tile;
+            if (x !== tempX || y !== tempY || res !== tempRes) {
+                tempNW = tileConfig.getTilePointNW(x, y, res);
             }
+            const type = feature.type;
+            const geo = this._convertGeometry(type, geometry, tempNW, extent, res);
+            feature.geometry = geo;
         }
     }
 
@@ -1681,15 +1679,14 @@ class VectorTileLayer extends maptalks.TileLayer {
                 const type = pick.data.feature.type;
                 pick.data.feature.type = "Feature";
                 // pick.data.feature.type = getFeatureType(pick.data.feature);
-                if (geometry.isMVTCoordinates) {
-                    pick.data.feature.geometry = this._convertGeometry(
-                        geometry.type || type,
-                        geometry,
-                        nw,
-                        extent,
-                        res
-                    );
-                }
+                pick.data.feature.geometry = this._convertGeometry(
+                    type,
+                    geometry,
+                    nw,
+                    extent,
+                    res
+                );
+
                 // pick.data.feature.geometry = this._convertGeometryCoords(geometry, nw, extent, res);
             }
         }
@@ -1704,9 +1701,16 @@ class VectorTileLayer extends maptalks.TileLayer {
         extent: number,
         res: number
     ) {
+        //not mvt coordinates
+        if (!geometry.isMVTCoordinates) {
+            return geometry;
+        }
         //the geometry has convert
         if (geometry.type && geometry.coordinates) {
             return geometry;
+        }
+        if (!isNumber(type)) {
+            type = geometry.type;
         }
         let geoType: string, coordinates: any;
         if (type === 1) {

--- a/packages/vt/src/layer/layer/VectorTileLayer.ts
+++ b/packages/vt/src/layer/layer/VectorTileLayer.ts
@@ -1648,16 +1648,6 @@ class VectorTileLayer extends maptalks.TileLayer {
         // }
         //always _convertPickedFeature
         results = this._convertPickedFeature(results);
-        //@ts-ignore
-        if (!this.options.features) {
-            //delete geometry info when layer disable features
-            results.forEach(item => {
-                if (item && item.data && item.data.feature) {
-                    delete item.data.feature.geometry;
-                }
-            });
-        }
-
         if (options && options.filter) {
             return results.filter(g => options.filter(g));
         } else {

--- a/packages/vt/src/layer/layer/VectorTileLayer.ts
+++ b/packages/vt/src/layer/layer/VectorTileLayer.ts
@@ -38,7 +38,7 @@ const defaultOptions: VectorTileLayerOptionsType = {
     forceRenderOnMoving: true,
     forceRenderOnRotating: true,
     tileSize: [512, 512],
-    features: false,
+    // features: false,
     schema: false,
     cascadeTiles: true,
     collision: true,
@@ -396,7 +396,7 @@ class VectorTileLayer extends maptalks.TileLayer {
             style: this.isDefaultRender()
                 ? { style: [], featureStyle: [] }
                 : this._getComputedStyle(),
-            features: options.debugTileData || options.features,
+            features: options.debugTileData || (options as any).features,
             schema: options.schema,
             pickingGeometry: options.pickingGeometry,
             projectionCode: this.getSpatialReference().getProjection().code,
@@ -2003,7 +2003,7 @@ function checkStyleExist(styles, idx) {
 export type VectorTileLayerOptionsType = {
     renderer?: "gl",
     altitudeProperty?: string,
-    features?: boolean,
+    // features?: boolean,
     schema?: boolean,
     collision?: boolean,
     collisionBuffserSize?: number,

--- a/packages/vt/src/layer/layer/VectorTileLayer.ts
+++ b/packages/vt/src/layer/layer/VectorTileLayer.ts
@@ -1648,6 +1648,16 @@ class VectorTileLayer extends maptalks.TileLayer {
         // }
         //always _convertPickedFeature
         results = this._convertPickedFeature(results);
+        //@ts-ignore
+        if (!this.options.features) {
+            //delete geometry info when layer disable features
+            results.forEach(item => {
+                if (item && item.data && item.data.feature) {
+                    delete item.data.feature.geometry;
+                }
+            });
+        }
+
         if (options && options.filter) {
             return results.filter(g => options.filter(g));
         } else {

--- a/packages/vt/src/layer/layer/VectorTileLayer.ts
+++ b/packages/vt/src/layer/layer/VectorTileLayer.ts
@@ -13,7 +13,7 @@ import type {
 import Color from 'color';
 import { getVectorPacker } from "../../packer/inject";
 import { compress, uncompress } from "./Compress";
-import { extend, hasOwn, isNil, isObject, isString, pushIn } from "../../common/Util";
+import { extend, hasOwn, isNil, isNumber, isObject, isString, pushIn } from "../../common/Util";
 
 import Ajax from "../../worker/util/Ajax";
 import VectorTileLayerRenderer from "../renderer/VectorTileLayerRenderer";
@@ -670,16 +670,15 @@ class VectorTileLayer extends maptalks.TileLayer {
             if (!feature || !tile || !geometry) {
                 continue;
             }
-            if (geometry.type) {
-                continue;
+            if (geometry.isMVTCoordinates) {
+                const { x, y, res, extent } = tile;
+                if (x !== tempX || y !== tempY || res !== tempRes) {
+                    tempNW = tileConfig.getTilePointNW(x, y, res);
+                }
+                const type = feature.type;
+                const geo = this._convertGeometry(geometry.type || type, geometry, tempNW, extent, res);
+                feature.geometry = geo;
             }
-            const { x, y, res, extent } = tile;
-            if (x !== tempX || y !== tempY || res !== tempRes) {
-                tempNW = tileConfig.getTilePointNW(x, y, res);
-            }
-            const type = feature.type;
-            const geo = this._convertGeometry(type, geometry, tempNW, extent, res);
-            feature.geometry = geo;
         }
     }
 

--- a/packages/vt/src/layer/renderer/VectorTileLayerRenderer.js
+++ b/packages/vt/src/layer/renderer/VectorTileLayerRenderer.js
@@ -649,7 +649,7 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
                 continue;
             }
             const { info, image } = cache;
-            const features = findFeatures(image);
+            const features = findFeatures(this.layer, image);
             renderedFeatures.push({
                 tile: { id: info.id, x: info.x, y: info.y, z: info.z, url: info.url },
                 current: !!this.tilesInView[info.id],
@@ -1690,11 +1690,11 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
             }
         });
         hits.forEach(item => {
-            const { data } = item;
+            const data = item.data || {};
             const tile = data.tile;
             if (tile) {
                 const tileCacheItem = this.tileCache.get(tile.id) || {};
-                wrapVTFeatureGeometryInfo(tileCacheItem.image, [data])
+                wrapVTFeatureGeometryInfo(this.layer.options.features, tileCacheItem.image, [data])
             }
         });
         return hits;
@@ -2414,7 +2414,7 @@ function getTileViewport(tileSize) {
     };
 }
 
-function findFeatures(image) {
+function findFeatures(layer, image) {
     if (!image.cache) {
         return [];
     }
@@ -2433,7 +2433,7 @@ function findFeatures(image) {
                 if (empty !== undefined) {
                     geometry.properties.features.empty = empty;
                 }
-                wrapVTFeatureGeometryInfo(image, features);
+                wrapVTFeatureGeometryInfo(layer.options.features, image, features);
                 return features;
             }
         }

--- a/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
+++ b/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
@@ -16,7 +16,7 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
             //is GeoJSONVectorTileLayer
             if (layer.getFeature && !isNil(feature)) {
                 const featureId = isObj ? feature.id : feature;
-                //query feature from main thread
+                //query feature from main thread,it may be null
                 const queryFeature = layer.getFeature(featureId);
                 if (queryFeature) {
                     //customProperties

--- a/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
+++ b/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
@@ -1,11 +1,11 @@
-import * as maptalks from 'maptalks';
+// import * as maptalks from 'maptalks';
 import { KEY_IDX } from '../../../common/Constant';
 import { extend, isObject, isNil } from '../../../common/Util';
 
 const KEY_IDX_NAME = (KEY_IDX + '').trim();
 
 // feaIndexes是VectorTileLayer中设置过filter时，符合条件的feature的编号，可以为null
-export default function convertToPainterFeatures(features, feaIndexes, layerId, symbol, layer, copy) {
+export default function convertToPainterFeatures(features, feaIndexes, layerId, symbol, layer) {
     const pluginFeas = {};
     if (hasFeature(features)) {
         const data = feaIndexes || features;
@@ -13,12 +13,14 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
         for (let ii = 0, ll = data.length; ii < ll; ii++) {
             let feature = feaIndexes ? features[feaIndexes[ii]] : features[ii];
             const isObj = feature && isObject(feature);
+            let propertiesHasMerged = false;
             //is GeoJSONVectorTileLayer
             if (layer.getFeature && !isNil(feature)) {
                 const featureId = isObj ? feature.id : feature;
                 //query feature from main thread,it may be null
                 const queryFeature = layer.getFeature(featureId);
                 if (queryFeature) {
+                    propertiesHasMerged = true;
                     //customProperties
                     let properties, customProps;
                     if (isObj) {
@@ -28,16 +30,19 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
                     }
                     feature = queryFeature;
                     feature.layer = layerId;
-                    if (properties || customProps) {
-                        feature.properties = feature.properties || {};
-                        //merge customProperties
-                        extend(feature.properties, properties || {}, customProps || {});
-                    }
+                    mergeFeatureProperties(feature, properties, customProps);
                 }
             }
-            if (layer instanceof maptalks.TileLayer) {
-                feature = proxyFea(feature, copy);
+            if (!propertiesHasMerged) {
+                if (isObj) {
+                    const properties = feature.properties;
+                    const customProps = feature.customProps;
+                    mergeFeatureProperties(feature, properties, customProps);
+                }
             }
+            // if (layer instanceof maptalks.TileLayer) {
+            //     feature = proxyFea(feature, copy);
+            // }
             const keyIdxValue = feaIndexes ? feaIndexes[ii] : feature[KEY_IDX_NAME];
             pluginFeas[keyIdxValue] = {
                 feature,
@@ -46,6 +51,14 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
         }
     }
     return pluginFeas;
+}
+
+function mergeFeatureProperties(feature, properties, customProps) {
+    if (properties || customProps) {
+        feature.properties = feature.properties || {};
+        //merge customProperties
+        extend(feature.properties, properties || {}, customProps || {});
+    }
 }
 
 function hasFeature(features) {
@@ -75,6 +88,7 @@ const proxyGetter = {
 
 const EMPTY_PROPS = {};
 
+// eslint-disable-next-line no-unused-vars
 function proxyFea(feature, copy) {
     const originalProperties = feature.properties;
     if (originalProperties && originalProperties[oldPropsKey]) {

--- a/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
+++ b/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
@@ -13,7 +13,7 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
         for (let ii = 0, ll = data.length; ii < ll; ii++) {
             let feature = feaIndexes ? features[feaIndexes[ii]] : features[ii];
             //is GeoJSONVectorTileLayer
-            if (layer.getFeature) {
+            if (layer.options['features'] === 'id' && layer.getFeature) {
                 const featureId = isObject(feature) ? feature.id : feature;
                 feature = layer.getFeature(featureId);
                 feature.layer = layerId;

--- a/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
+++ b/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
@@ -18,6 +18,7 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
                 const featureId = isObj ? feature.id : feature;
                 //query feature from main thread,it may be null
                 const queryFeature = layer.getFeature(featureId);
+                //it may be null
                 if (queryFeature) {
                     //customProperties
                     let properties, customProps;

--- a/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
+++ b/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
@@ -12,7 +12,7 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
         //[feature index, style index]
         for (let ii = 0, ll = data.length; ii < ll; ii++) {
             let feature = feaIndexes ? features[feaIndexes[ii]] : features[ii];
-            if (layer.getFeature) {
+            if (layer.options['features'] === 'id' && layer.getFeature) {
                 const featureId = isObject(feature) ? feature.id : feature;
                 feature = layer.getFeature(featureId);
                 feature.layer = layerId;

--- a/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
+++ b/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
@@ -30,6 +30,7 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
                     }
                     feature = queryFeature;
                     feature.layer = layerId;
+                    //merge properties
                     mergeFeatureProperties(feature, properties, customProps);
                 }
             }
@@ -37,6 +38,7 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
                 if (isObj) {
                     const properties = feature.properties;
                     const customProps = feature.customProps;
+                    //merge properties
                     mergeFeatureProperties(feature, properties, customProps);
                 }
             }

--- a/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
+++ b/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
@@ -12,11 +12,11 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
         //[feature index, style index]
         for (let ii = 0, ll = data.length; ii < ll; ii++) {
             let feature = feaIndexes ? features[feaIndexes[ii]] : features[ii];
-            if (layer.options['features'] === 'id' && layer.getFeature) {
-                const featureId = isObject(feature) ? feature.id : feature;
-                feature = layer.getFeature(featureId);
-                feature.layer = layerId;
-            }
+            // if (layer.options['features'] === 'id' && layer.getFeature) {
+            const featureId = isObject(feature) ? feature.id : feature;
+            feature = layer.getFeature(featureId);
+            feature.layer = layerId;
+            // }
             if (layer instanceof maptalks.TileLayer) {
                 feature = proxyFea(feature, copy);
             }

--- a/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
+++ b/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
@@ -16,18 +16,21 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
             //is GeoJSONVectorTileLayer
             if (layer.getFeature && !isNil(feature)) {
                 const featureId = isObj ? feature.id : feature;
-                //customProperties
-                let properties, customProps;
-                if (isObj) {
-                    properties = feature.properties;
-                    customProps = feature.customProps;
-                }
-                feature = layer.getFeature(featureId);
-                feature.layer = layerId;
-                if ((properties || customProps) && isObject(feature)) {
-                    feature.properties = feature.properties || {};
-                    //merge customProperties
-                    extend(feature.properties, properties || {}, customProps || {});
+                const queryFeature = layer.getFeature(featureId);
+                if (queryFeature) {
+                    //customProperties
+                    let properties, customProps;
+                    if (isObj) {
+                        properties = feature.properties;
+                        customProps = feature.customProps;
+                    }
+                    feature = queryFeature;
+                    feature.layer = layerId;
+                    if ((properties || customProps) && isObject(feature)) {
+                        feature.properties = feature.properties || {};
+                        //merge customProperties
+                        extend(feature.properties, properties || {}, customProps || {});
+                    }
                 }
             }
             if (layer instanceof maptalks.TileLayer) {

--- a/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
+++ b/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
@@ -1,11 +1,11 @@
-// import * as maptalks from 'maptalks';
+import * as maptalks from 'maptalks';
 import { KEY_IDX } from '../../../common/Constant';
 import { extend, isObject, isNil } from '../../../common/Util';
 
 const KEY_IDX_NAME = (KEY_IDX + '').trim();
 
 // feaIndexes是VectorTileLayer中设置过filter时，符合条件的feature的编号，可以为null
-export default function convertToPainterFeatures(features, feaIndexes, layerId, symbol, layer) {
+export default function convertToPainterFeatures(features, feaIndexes, layerId, symbol, layer, copy) {
     const pluginFeas = {};
     if (hasFeature(features)) {
         const data = feaIndexes || features;
@@ -13,14 +13,12 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
         for (let ii = 0, ll = data.length; ii < ll; ii++) {
             let feature = feaIndexes ? features[feaIndexes[ii]] : features[ii];
             const isObj = feature && isObject(feature);
-            let propertiesHasMerged = false;
             //is GeoJSONVectorTileLayer
             if (layer.getFeature && !isNil(feature)) {
                 const featureId = isObj ? feature.id : feature;
                 //query feature from main thread,it may be null
                 const queryFeature = layer.getFeature(featureId);
                 if (queryFeature) {
-                    propertiesHasMerged = true;
                     //customProperties
                     let properties, customProps;
                     if (isObj) {
@@ -34,17 +32,9 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
                     mergeFeatureProperties(feature, properties, customProps);
                 }
             }
-            if (!propertiesHasMerged) {
-                if (isObj) {
-                    const properties = feature.properties;
-                    const customProps = feature.customProps;
-                    //merge properties
-                    mergeFeatureProperties(feature, properties, customProps);
-                }
+            if (layer instanceof maptalks.TileLayer) {
+                feature = proxyFea(feature, copy);
             }
-            // if (layer instanceof maptalks.TileLayer) {
-            //     feature = proxyFea(feature, copy);
-            // }
             const keyIdxValue = feaIndexes ? feaIndexes[ii] : feature[KEY_IDX_NAME];
             pluginFeas[keyIdxValue] = {
                 feature,

--- a/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
+++ b/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
@@ -12,7 +12,8 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
         //[feature index, style index]
         for (let ii = 0, ll = data.length; ii < ll; ii++) {
             let feature = feaIndexes ? features[feaIndexes[ii]] : features[ii];
-            if (layer.options['features'] === 'id' && layer.getFeature) {
+            //is GeoJSONVectorTileLayer
+            if (layer.getFeature) {
                 const featureId = isObject(feature) ? feature.id : feature;
                 feature = layer.getFeature(featureId);
                 feature.layer = layerId;

--- a/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
+++ b/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
@@ -12,11 +12,11 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
         //[feature index, style index]
         for (let ii = 0, ll = data.length; ii < ll; ii++) {
             let feature = feaIndexes ? features[feaIndexes[ii]] : features[ii];
-            // if (layer.options['features'] === 'id' && layer.getFeature) {
-            const featureId = isObject(feature) ? feature.id : feature;
-            feature = layer.getFeature(featureId);
-            feature.layer = layerId;
-            // }
+            if (layer.getFeature) {
+                const featureId = isObject(feature) ? feature.id : feature;
+                feature = layer.getFeature(featureId);
+                feature.layer = layerId;
+            }
             if (layer instanceof maptalks.TileLayer) {
                 feature = proxyFea(feature, copy);
             }

--- a/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
+++ b/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
@@ -1,6 +1,6 @@
 import * as maptalks from 'maptalks';
 import { KEY_IDX } from '../../../common/Constant';
-import { extend } from '../../../common/Util';
+import { extend, isObject } from '../../../common/Util';
 
 const KEY_IDX_NAME = (KEY_IDX + '').trim();
 
@@ -13,7 +13,8 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
         for (let ii = 0, ll = data.length; ii < ll; ii++) {
             let feature = feaIndexes ? features[feaIndexes[ii]] : features[ii];
             if (layer.options['features'] === 'id' && layer.getFeature) {
-                feature = layer.getFeature(feature);
+                const featureId = isObject(feature) ? feature.id : feature;
+                feature = layer.getFeature(featureId);
                 feature.layer = layerId;
             }
             if (layer instanceof maptalks.TileLayer) {
@@ -46,11 +47,11 @@ export const oldPropsKey = '__original_properties';
 export const externalPropsKey = '__external_properties';
 
 const proxyGetter = {
-    get: function(obj, prop) {
+    get: function (obj, prop) {
         return prop in obj ? obj[prop] : (obj[oldPropsKey][prop] || obj[externalPropsKey] && obj[externalPropsKey][prop]);
     },
-    has: function(obj, prop) {
-        return (prop in obj) || (prop in obj[oldPropsKey])  || obj[externalPropsKey] && (prop in obj[externalPropsKey]);
+    has: function (obj, prop) {
+        return (prop in obj) || (prop in obj[oldPropsKey]) || obj[externalPropsKey] && (prop in obj[externalPropsKey]);
     }
 };
 

--- a/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
+++ b/packages/vt/src/layer/renderer/utils/convert_to_painter_features.js
@@ -16,17 +16,19 @@ export default function convertToPainterFeatures(features, feaIndexes, layerId, 
             //is GeoJSONVectorTileLayer
             if (layer.getFeature && !isNil(feature)) {
                 const featureId = isObj ? feature.id : feature;
+                //query feature from main thread
                 const queryFeature = layer.getFeature(featureId);
                 if (queryFeature) {
                     //customProperties
                     let properties, customProps;
                     if (isObj) {
+                        //get properties from worker data
                         properties = feature.properties;
                         customProps = feature.customProps;
                     }
                     feature = queryFeature;
                     feature.layer = layerId;
-                    if ((properties || customProps) && isObject(feature)) {
+                    if (properties || customProps) {
                         feature.properties = feature.properties || {};
                         //merge customProperties
                         extend(feature.properties, properties || {}, customProps || {});

--- a/packages/vt/test/specs/layer.spec.js
+++ b/packages/vt/test/specs/layer.spec.js
@@ -200,54 +200,54 @@ describe('layer related specs', () => {
         layer.addTo(map);
     });
 
-    it('transient features', done => {
-        map = new maptalks.Map(container, DEFAULT_VIEW);
-        const layer = new GeoJSONVectorTileLayer('gvt', {
-            features: 'transient',
-            data: polygon,
-            style: [
-                {
-                    filter: true,
-                    renderPlugin: {
-                        type: 'fill',
-                        dataConfig: {
-                            type: 'fill'
-                        }
-                    },
-                    symbol: {
-                        polygonFill: '#f00',
-                        polygonOpacity: {
-                            type: 'interval',
-                            property: 'levels',
-                            stops: [
-                                [0, 1],
-                                [200, 1]
-                            ]
-                        }
-                    }
-                }
-            ]
-        });
-        let hasFeatures = false;
-        let hit = false;
-        layer.on('tileload', e => {
-            if (!hasFeatures && e.tileImage && e.tileImage.features) {
-                hasFeatures = true;
-                assert(e.tileImage.features.length > 0);
-            }
-        })
-        layer.on('_transientfeature', e => {
-            if (!hit) {
-                assert(hasFeatures);
-                hit = true;
-                const feature = e.tileImage.data[0].features[0].feature;
-                // 保存了fn-type所需要的properties
-                assert(feature.properties['__original_properties'].levels === 3000);
-                assert(feature.properties['__original_properties'].foo === undefined);
-                done();
-            }
+    // it('transient features', done => {
+    //     map = new maptalks.Map(container, DEFAULT_VIEW);
+    //     const layer = new GeoJSONVectorTileLayer('gvt', {
+    //         features: 'transient',
+    //         data: polygon,
+    //         style: [
+    //             {
+    //                 filter: true,
+    //                 renderPlugin: {
+    //                     type: 'fill',
+    //                     dataConfig: {
+    //                         type: 'fill'
+    //                     }
+    //                 },
+    //                 symbol: {
+    //                     polygonFill: '#f00',
+    //                     polygonOpacity: {
+    //                         type: 'interval',
+    //                         property: 'levels',
+    //                         stops: [
+    //                             [0, 1],
+    //                             [200, 1]
+    //                         ]
+    //                     }
+    //                 }
+    //             }
+    //         ]
+    //     });
+    //     let hasFeatures = false;
+    //     let hit = false;
+    //     layer.on('tileload', e => {
+    //         if (!hasFeatures && e.tileImage && e.tileImage.features) {
+    //             hasFeatures = true;
+    //             assert(e.tileImage.features.length > 0);
+    //         }
+    //     })
+    //     layer.on('_transientfeature', e => {
+    //         if (!hit) {
+    //             assert(hasFeatures);
+    //             hit = true;
+    //             const feature = e.tileImage.data[0].features[0].feature;
+    //             // 保存了fn-type所需要的properties
+    //             assert(feature.properties['__original_properties'].levels === 3000);
+    //             assert(feature.properties['__original_properties'].foo === undefined);
+    //             done();
+    //         }
 
-        });
-        layer.addTo(map);
-    });
+    //     });
+    //     layer.addTo(map);
+    // });
 });

--- a/packages/vt/test/specs/picking.spec.js
+++ b/packages/vt/test/specs/picking.spec.js
@@ -706,9 +706,9 @@ describe('picking specs', () => {
                     customProperties: [
                         {
                             "filter": true,
-                              "properties": {
+                            "properties": {
                                 "custom_prop_line_batch_id": "admin-0-boundary-bg"
-                              }
+                            }
                         }
                     ],
                     symbol: {
@@ -906,7 +906,7 @@ describe('picking specs', () => {
 
 
 
-    it('should return feature properties used in symbol', done => {
+        it('should return feature properties used in symbol', done => {
             const options = {
                 // 不返回features
                 features: 0,
@@ -1116,7 +1116,7 @@ describe('picking specs', () => {
             const layer = new GeoJSONVectorTileLayer('gvt', options);
             layer.once('canvasisdirty', () => {
                 const hit = layer.identify([13.41720, 52.52952])[0];
-                const expectedFeature = { "type": "Feature", "geometry": { "type": "Polygon","coordinates": [[[13.417135053741617,52.52956625878565],[13.417226248848124,52.52956625878565],[13.417226248848124,52.52946625878565],[13.417135053741617,52.52946625878565],[13.417135053741617,52.52956625878565]]] },"properties": { "type": 1, "color": "#f00", "foo": "bar", "foo1": "bar1" },"id": 0,"layer": 0 };
+                const expectedFeature = { "type": "Feature", "geometry": { "type": "Polygon", "coordinates": [[[13.417135053741617, 52.52956625878565], [13.417226248848124, 52.52956625878565], [13.417226248848124, 52.52946625878565], [13.417135053741617, 52.52946625878565], [13.417135053741617, 52.52956625878565]]] }, "properties": { "type": 1, "color": "#f00", "foo": "bar", "foo1": "bar1" }, "id": 0, "layer": 0 };
                 assert.deepEqual(hit.coordinate, [13.417199426755861, 52.52951893867223, -0.000006980199889114576]);
                 assert.deepEqual(expectedFeature, hit.data.feature);
                 done();
@@ -1253,15 +1253,15 @@ describe('picking specs', () => {
             map = new maptalks.Map(container, options.view || DEFAULT_VIEW);
             const layer = new PointLayer('gvt', [marker]);
             new GroupGLLayer('group', [layer], {
-        sceneConfig: {
-          environment: {
-            enable: true,
-            mode: 1,
-            level: 0,
-            brightness: 0,
-          },
-        },
-      }).addTo(map);
+                sceneConfig: {
+                    environment: {
+                        enable: true,
+                        mode: 1,
+                        level: 0,
+                        brightness: 0,
+                    },
+                },
+            }).addTo(map);
             layer.once('canvasisdirty', () => {
                 const redPoint = layer.identify([0, 0]);
                 assert(redPoint[0].geometry instanceof maptalks.Marker);
@@ -1638,10 +1638,18 @@ describe('picking specs', () => {
             count++;
             if (count === 5) {
                 const picked = layer.identifyAtPoint(new maptalks.Point(map.width / 2, map.height / 2));
-                assert(picked[0].data.feature.type === 'Feature');
-                assert(picked[0].data.feature.geometry.type.includes('Polygon'));
-                assert(Math.abs(picked[0].data.feature.geometry.coordinates[0][0][0]) < 10);
-                assert(Math.abs(picked[0].data.feature.geometry.coordinates[0][0][1]) < 10);
+                const feature = picked[0].data.feature;
+                assert(feature.type === 'Feature');
+                let coordinates = feature.geometry.coordinates;
+                const type = feature.geometry.type;
+                assert(type.includes('Polygon'));
+                if (type === 'MultiPolygon') {
+                    coordinates = coordinates[0][0][0];
+                } else {
+                    coordinates = coordinates[0][0];
+                }
+                assert(Math.abs(coordinates[0]) < 10);
+                assert(Math.abs(coordinates[1]) < 10);
                 done();
             }
         });
@@ -1650,7 +1658,7 @@ describe('picking specs', () => {
 
     it('ciskip should enable stencil in VectorTileLayer FillPainter pick, maptalks/issues#832', done => {
         map = new maptalks.Map(container, {
-            center: [121.52861644,31.23331691],
+            center: [121.52861644, 31.23331691],
             zoom: 19,
             devicePixelRatio: 1
         });

--- a/packages/vt/test/specs/picking.spec.js
+++ b/packages/vt/test/specs/picking.spec.js
@@ -168,7 +168,7 @@ describe('picking specs', () => {
                             'height': 20000
                         },
                         'id': 0,
-                        'layer': 0
+                        'layer': '0'
                     },
                 },
                 'point': [736.00012, 736.00012, -0.00098],
@@ -607,7 +607,10 @@ describe('picking specs', () => {
                         },
                         'id': 0,
                         'layer': 0,
-                        "properties": {}
+                        "properties": {
+                            "mapbox_clip_end": 1,
+                            "mapbox_clip_start": 0
+                        }
                     },
                     'symbol': {
                         'lineColor': '#f00'
@@ -671,7 +674,10 @@ describe('picking specs', () => {
                         },
                         'id': 0,
                         'layer': 0,
-                        "properties": {}
+                        "properties": {
+                            "mapbox_clip_end": 1,
+                            "mapbox_clip_start": 0
+                        }
                     },
                     'symbol': {
                         'lineColor': '#f00',
@@ -735,18 +741,18 @@ describe('picking specs', () => {
                 const expected = {
                     "feature": {
                         "type": "Feature",
-                        "layer": "0",
+                        "layer": 0,
                         "id": 0,
                         "geometry": {
                             "type": "LineString",
-                            "coordinates": [[13.417135030031202, 52.52956633939653], [13.417226225137709, 52.52956633939653]]
+                            "coordinates": [[13.417135053741617, 52.52956625878565], [13.417226248848124, 52.52956625878565]]
                         },
                         "properties": {
                             "custom_prop_line_batch_id": "admin-0-boundary-bg",
                             "mapbox_clip_start": 0,
                             "mapbox_clip_end": 1
                         },
-                        "extent": 8192
+                        // "extent": 8192
                     },
                     "symbol": {
                         "lineColor": "#f00",
@@ -820,7 +826,9 @@ describe('picking specs', () => {
                         },
                         'id': 0,
                         'layer': 0,
-                        'properties': {}
+                        'properties': {
+                            "maptalks_ombb": [[1493588.6420870982, 6896450.095810079], [1493588.6420870982, 6896431.797296667], [1493598.7938799174, 6896431.797296667], [1493598.7938799174, 6896450.095810079], 0]
+                        }
                     },
                     'symbol': {
                         'polygonFill': '#f00',
@@ -895,7 +903,9 @@ describe('picking specs', () => {
                         },
                         'id': 0,
                         'layer': 0,
-                        'properties': {}
+                        'properties': {
+                            "maptalks_ombb": [[1493588.6420870982, 6896450.095810079], [1493588.6420870982, 6896431.797296667], [1493598.7938799174, 6896431.797296667], [1493598.7938799174, 6896450.095810079], 0]
+                        }
                     },
                     'symbol': {
                         'lineColor': '#f00',
@@ -973,12 +983,11 @@ describe('picking specs', () => {
             layer.once('canvasisdirty', () => {
                 const redPoint = layer.identify([13.41720, 52.52952]);
                 const expected = {
-                    "type": 3,
-                    "layer": "0",
+                    "type": 'Feature',
+                    "layer": 0,
                     "id": 0,
                     "properties": {
-                        "type": 1,
-                        "color": "#f00"
+                        "type": 1, "color": "#f00", "foo": "bar", "foo1": "bar1"
                     }
                 };
                 delete redPoint[0].data.feature["__fea_idx"];
@@ -1042,7 +1051,10 @@ describe('picking specs', () => {
                         },
                         'id': 0,
                         'layer': 0,
-                        'properties': {}
+                        'properties': {
+                            "mapbox_clip_end": 1,
+                            "mapbox_clip_start": 0
+                        }
                     },
                     'symbol': {
                         'lineColor': '#f00',
@@ -1122,7 +1134,8 @@ describe('picking specs', () => {
             const layer = new GeoJSONVectorTileLayer('gvt', options);
             layer.once('canvasisdirty', () => {
                 const hit = layer.identify([13.41720, 52.52952])[0];
-                const expectedFeature = { "type": "Feature", "geometry": { "type": "Polygon", "coordinates": [[[13.417135053741617, 52.52956625878565], [13.417226248848124, 52.52956625878565], [13.417226248848124, 52.52946625878565], [13.417135053741617, 52.52946625878565], [13.417135053741617, 52.52956625878565]]] }, "properties": { "type": 1, "color": "#f00", "foo": "bar", "foo1": "bar1" }, "id": 0, "layer": 0 };
+                const expectedFeature = {"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[13.417135053741617,52.52956625878565],[13.417226248848124,52.52956625878565],[13.417226248848124,52.52946625878565],[13.417135053741617,52.52946625878565],[13.417135053741617,52.52956625878565]]]},"properties":{"type":1,"color":"#f00","foo":"bar","foo1":"bar1","maptalks_ombb":[[1493588.6420870982,6896450.095810079],[1493588.6420870982,6896431.797296667],[1493598.7938799174,6896431.797296667],[1493598.7938799174,6896450.095810079],0]},"id":0,"layer":0}
+
                 assert.deepEqual(hit.coordinate, [13.417199426755861, 52.52951893867223, -0.000006980199889114576]);
                 assert.deepEqual(expectedFeature, hit.data.feature);
                 done();

--- a/packages/vt/test/specs/picking.spec.js
+++ b/packages/vt/test/specs/picking.spec.js
@@ -1639,7 +1639,7 @@ describe('picking specs', () => {
             if (count === 5) {
                 const picked = layer.identifyAtPoint(new maptalks.Point(map.width / 2, map.height / 2));
                 assert(picked[0].data.feature.type === 'Feature');
-                assert(picked[0].data.feature.geometry.type === 'Polygon');
+                assert(picked[0].data.feature.geometry.type.includes('Polygon'));
                 assert(Math.abs(picked[0].data.feature.geometry.coordinates[0][0][0]) < 10);
                 assert(Math.abs(picked[0].data.feature.geometry.coordinates[0][0][1]) < 10);
                 done();

--- a/packages/vt/test/specs/picking.spec.js
+++ b/packages/vt/test/specs/picking.spec.js
@@ -924,7 +924,7 @@ describe('picking specs', () => {
 
         it('should return feature properties used in symbol', done => {
             const options = {
-                // 不返回features
+                // 不返回features,永远返回features了
                 features: 0,
                 data: {
                     type: 'FeatureCollection',
@@ -986,6 +986,7 @@ describe('picking specs', () => {
                     "type": 'Feature',
                     "layer": 0,
                     "id": 0,
+                    "geometry": { "type": "Polygon", "coordinates": [[[13.417135053741617, 52.52956625878565], [13.417226248848124, 52.52956625878565], [13.417226248848124, 52.52946625878565], [13.417135053741617, 52.52946625878565], [13.417135053741617, 52.52956625878565]]] },
                     "properties": {
                         "type": 1, "color": "#f00", "foo": "bar", "foo1": "bar1"
                     }
@@ -1134,7 +1135,7 @@ describe('picking specs', () => {
             const layer = new GeoJSONVectorTileLayer('gvt', options);
             layer.once('canvasisdirty', () => {
                 const hit = layer.identify([13.41720, 52.52952])[0];
-                const expectedFeature = {"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[13.417135053741617,52.52956625878565],[13.417226248848124,52.52956625878565],[13.417226248848124,52.52946625878565],[13.417135053741617,52.52946625878565],[13.417135053741617,52.52956625878565]]]},"properties":{"type":1,"color":"#f00","foo":"bar","foo1":"bar1","maptalks_ombb":[[1493588.6420870982,6896450.095810079],[1493588.6420870982,6896431.797296667],[1493598.7938799174,6896431.797296667],[1493598.7938799174,6896450.095810079],0]},"id":0,"layer":0}
+                const expectedFeature = { "type": "Feature", "geometry": { "type": "Polygon", "coordinates": [[[13.417135053741617, 52.52956625878565], [13.417226248848124, 52.52956625878565], [13.417226248848124, 52.52946625878565], [13.417135053741617, 52.52946625878565], [13.417135053741617, 52.52956625878565]]] }, "properties": { "type": 1, "color": "#f00", "foo": "bar", "foo1": "bar1", "maptalks_ombb": [[1493588.6420870982, 6896450.095810079], [1493588.6420870982, 6896431.797296667], [1493598.7938799174, 6896431.797296667], [1493598.7938799174, 6896450.095810079], 0] }, "id": 0, "layer": 0 }
 
                 assert.deepEqual(hit.coordinate, [13.417199426755861, 52.52951893867223, -0.000006980199889114576]);
                 assert.deepEqual(expectedFeature, hit.data.feature);

--- a/packages/vt/test/specs/update.fn-type.spec.js
+++ b/packages/vt/test/specs/update.fn-type.spec.js
@@ -84,14 +84,16 @@ describe('update function type style specs', () => {
     });
 
     it('property function type to property function type', done => {
-        const symbol = { lineColor: {
-            type: 'categorical',
-            property: 'type',
-            stops: [
-                [1, '#f00'],
-                [2, '#f00'],
-            ]
-        }, lineWidth: 8, lineOpacity: 1 };
+        const symbol = {
+            lineColor: {
+                type: 'categorical',
+                property: 'type',
+                stops: [
+                    [1, '#f00'],
+                    [2, '#f00'],
+                ]
+            }, lineWidth: 8, lineOpacity: 1
+        };
         assertChangeStyle(done, symbol, [255, 0, 0, 255], [0, 255, 0, 255], layer => {
             layer.updateSymbol(0, {
                 lineColor: {
@@ -129,20 +131,22 @@ describe('update function type style specs', () => {
     });
 
     it('property-zoom based to normal color', done => {
-        const symbol = { lineColor: {
-            type: 'categorical',
-            property: 'type',
-            stops: [
-                [1, {
-                    type: 'interval',
-                    stops: [
-                        [map.getZoom(), '#00f'],
-                        [map.getZoom() + 2, '#f00'],
-                    ]
-                }],
-                [2, '#f00'],
-            ]
-        }, lineWidth: 8, lineOpacity: 1 };
+        const symbol = {
+            lineColor: {
+                type: 'categorical',
+                property: 'type',
+                stops: [
+                    [1, {
+                        type: 'interval',
+                        stops: [
+                            [map.getZoom(), '#00f'],
+                            [map.getZoom() + 2, '#f00'],
+                        ]
+                    }],
+                    [2, '#f00'],
+                ]
+            }, lineWidth: 8, lineOpacity: 1
+        };
         assertChangeStyle(done, symbol, [0, 0, 255, 255], [255, 0, 0, 255], layer => {
             layer.updateSymbol(0, {
                 lineColor: '#f00'
@@ -152,20 +156,22 @@ describe('update function type style specs', () => {
 
     //TODO 目前暂时不支持zoom-property形式的function type
     it.skip('zoom-property-zoom based to normal color', done => {
-        const symbol = { lineColor: {
-            type: 'interval',
-            stops: [
-                [map.getZoom(), {
-                    type: 'categorical',
-                    property: 'type',
-                    stops: [
-                        [1, '#00f'],
-                        [2, '#f00'],
-                    ]
-                }],
-                [map.getZoom() + 2, '#f00'],
-            ]
-        }, lineWidth: 8, lineOpacity: 1 };
+        const symbol = {
+            lineColor: {
+                type: 'interval',
+                stops: [
+                    [map.getZoom(), {
+                        type: 'categorical',
+                        property: 'type',
+                        stops: [
+                            [1, '#00f'],
+                            [2, '#f00'],
+                        ]
+                    }],
+                    [map.getZoom() + 2, '#f00'],
+                ]
+            }, lineWidth: 8, lineOpacity: 1
+        };
         assertChangeStyle(done, symbol, [0, 0, 255, 255], [255, 0, 0, 255], layer => {
             layer.updateSymbol(0, {
                 lineColor: '#f00'
@@ -174,13 +180,15 @@ describe('update function type style specs', () => {
     });
 
     it('zoom based to normal color', done => {
-        const symbol = { lineColor: {
-            type: 'interval',
-            stops: [
-                [map.getZoom(), '#00f'],
-                [map.getZoom() + 2, '#f00'],
-            ]
-        }, lineWidth: 8, lineOpacity: 1 };
+        const symbol = {
+            lineColor: {
+                type: 'interval',
+                stops: [
+                    [map.getZoom(), '#00f'],
+                    [map.getZoom() + 2, '#f00'],
+                ]
+            }, lineWidth: 8, lineOpacity: 1
+        };
         assertChangeStyle(done, symbol, [0, 0, 255, 255], [255, 0, 0, 255], layer => {
             layer.updateSymbol(0, {
                 lineColor: '#f00'
@@ -214,6 +222,7 @@ describe('update function type style specs', () => {
         layer.once('canvasisdirty', () => {
             dirty = true;
         });
+        let doned = false;
         //因为是setStyle时，数据会被清空重绘，所以需要监听两次canvasisdirty
         layer.on(isSetStyle ? 'canvasisdirty' : 'canvasisdirty', () => {
             if (!dirty) {
@@ -229,7 +238,10 @@ describe('update function type style specs', () => {
                 const pixel = readPixel(layer.getRenderer().canvas, x / 2, y / 2);
                 //变成绿色
                 assert.deepEqual(pixel, expectedColor);
-                done();
+                if (!doned) {
+                    done();
+                    doned = true;
+                }
             }
         });
         layer.addTo(map);

--- a/packages/vt/test/unit/Layer.GeoJSON.spec.js
+++ b/packages/vt/test/unit/Layer.GeoJSON.spec.js
@@ -272,8 +272,10 @@ describe('GeoJSONVectorTileLayer', () => {
         layer.on('layerload', () => {
             count++;
             if (count === 1) {
-                assert.deepStrictEqual(layer.getComputedStyle().style[0].renderPlugin.sceneConfig, { foo: 1 });
-                done();
+                setTimeout(() => {
+                    assert.deepStrictEqual(layer.getComputedStyle().style[0].renderPlugin.sceneConfig, { foo: 1 });
+                    done();
+                }, 1000);
             }
         });
         layer.addTo(map);


### PR DESCRIPTION
优化vt数据 feature.geometry的 worker数据传输

问题分析：

- pick时需要feature.geometry 信息，这个用户的必要的需求
- getRenderedFeatures需要 geomety 信息
- pick是大众需求，getRenderedFeatures是小众需求，即pick 使用的概率要远远高于getRenderedFeatures

改进方案：

- worker里总是返回全量的feature.geometry信息
- 将全量的features信息编码成typearray
-  主线程里按需解码对应的瓦片，补全featuer geometry的信息
- 每个瓦片只需要解码一次

优点：

- 保证worker返回主线程的通信效率的稳定，不会因为返回feature.geometry导致传输效率下降
-  pick时只需要解码一个瓦片，原来老的方式当用户配置了pickingGeometry，每个瓦片都要进行worker的数据结构化的，假设当前有20个瓦片，意味着需要worker传输20个features集合，而pick是一个瓦片，原来的方式浪费严重

缺点：

- 需要再主线程里解码 typearray
- 当用户getRenderedFeatures时，要解码所有的瓦片，还不如原来的 worker clone geometry，但是毕竟是小众需求，总体而已比原来的方式要好一点