### PR TITLE
fix: remove 'drawtopstart' event listener in GeometryEditor.stop to prevent warnings

### DIFF
--- a/packages/maptalks/src/geometry/editor/GeometryEditor.ts
+++ b/packages/maptalks/src/geometry/editor/GeometryEditor.ts
@@ -346,6 +346,7 @@ class GeometryEditor extends Eventable(Class) {
             this.fire('remove');
             return;
         }
+        map.off('drawtopstart', this._refresh, this);
         this._geometry.config('draggable', this._geometryDraggble);
         if (this._shadow) {
             this._shadow.off(SHADOW_DRAG_EVENTS, this._shadowDragEvent, this);


### PR DESCRIPTION
stop时没移除事件，会报警告如下：

```log
Eventable.ts:105 Map {options: Proxy(Object), _initHooksCalled: true, _isUpdatingOptions: false, isMap: true, VERSION: '1.9.0', …} "find 'drawtopstart' handler:" ƒ _refresh() {
    if (this._refreshHooks) {
      for (var i = this._refreshHooks.length - 1; i >= 0; i--) {
        this._refreshHooks[i].call(this);
      }
    }
  } ' The old listener function will be removed'
on @ Eventable.ts:105
prepare @ GeometryEditor.ts:230
start @ GeometryEditor.ts:270
_exeAndReset @ GeometryEditor.ts:1548
_fire @ Eventable.ts:416
fire @ Eventable.ts:310
_fireEvent @ Geometry.ts:1807
onShapeChanged @ Geometry.ts:1665
setHeight @ Rectangle.ts:116
setBounds @ tg-map-core.mjs:10265
bounds @ TgRectangle.vue:46
callWithErrorHandling @ runtime-core.esm-bundler.js:199
callWithAsyncErrorHandling @ runtime-core.esm-bundler.js:206
baseWatchOptions.call @ runtime-core.esm-bundler.js:6246
job @ reactivity.esm-bundler.js:1826
flushPreFlushCbs @ runtime-core.esm-bundler.js:356
updateComponentPreRender @ runtime-core.esm-bundler.js:5491
componentUpdateFn @ runtime-core.esm-bundler.js:5410
run @ reactivity.esm-bundler.js:237
updateComponent @ runtime-core.esm-bundler.js:5285
processComponent @ runtime-core.esm-bundler.js:5220
patch @ runtime-core.esm-bundler.js:4727
patchBlockChildren @ runtime-core.esm-bundler.js:5081
processFragment @ runtime-core.esm-bundler.js:5157
patch @ runtime-core.esm-bundler.js:4701
patchBlockChildren @ runtime-core.esm-bundler.js:5081
patchElement @ runtime-core.esm-bundler.js:4999
processElement @ runtime-core.esm-bundler.js:4858
patch @ runtime-core.esm-bundler.js:4715
componentUpdateFn @ runtime-core.esm-bundler.js:5433
run @ reactivity.esm-bundler.js:237
updateComponent @ runtime-core.esm-bundler.js:5285
processComponent @ runtime-core.esm-bundler.js:5220
patch @ runtime-core.esm-bundler.js:4727
componentUpdateFn @ runtime-core.esm-bundler.js:5433
run @ reactivity.esm-bundler.js:237
runIfDirty @ reactivity.esm-bundler.js:275
callWithErrorHandling @ runtime-core.esm-bundler.js:199
flushJobs @ runtime-core.esm-bundler.js:408
Promise.then
queueFlush @ runtime-core.esm-bundler.js:322
queueJob @ runtime-core.esm-bundler.js:317
effect2.scheduler @ runtime-core.esm-bundler.js:5475
trigger @ reactivity.esm-bundler.js:265
endBatch @ reactivity.esm-bundler.js:323
trigger @ reactivity.esm-bundler.js:736
set @ reactivity.esm-bundler.js:1019
_createElementVNode.onUpdate:modelValue._cache.<computed>._cache.<computed> @ ShapeDemo.vue:46
(anonymous) @ runtime-dom.esm-bundler.js:1503

```