### PR TITLE
fix:沿线道路文字修改：之前渲染上会存在可视域范围内有些道路文字不显示，即道路名称（文字沿线布置）会在特定角度下突然消失，旋转地图后又重…

### DIFF
--- a/packages/vt/src/layer/plugins/painters/glsl/line.frag
+++ b/packages/vt/src/layer/plugins/painters/glsl/line.frag
@@ -37,14 +37,19 @@ uniform float layerOpacity;
     uniform sampler2D linePatternFile;
     uniform vec2 atlasSize;
     uniform float flipY;
-    #ifdef HAS_PATTERN_ANIM
-        varying float vLinePatternAnimSpeed;
-    #else
+    #if defined(HAS_PATTERN_ANIM) || defined(HAS_PATTERN_GAP)
+        varying vec2 vLinePatternAnimAndGap;
+        #ifdef HAS_PATTERN_ANIM
+            #define vLinePatternAnimSpeed vLinePatternAnimAndGap.x
+        #endif
+        #ifdef HAS_PATTERN_GAP
+            #define vLinePatternGap vLinePatternAnimAndGap.y
+        #endif
+    #endif
+    #ifndef HAS_PATTERN_ANIM
         uniform float linePatternAnimSpeed;
     #endif
-    #ifdef HAS_PATTERN_GAP
-        varying float vLinePatternGap;
-    #else
+    #ifndef HAS_PATTERN_GAP
         uniform float linePatternGap;
     #endif
     uniform vec4 linePatterGapColor;
@@ -57,9 +62,17 @@ uniform float layerOpacity;
         return (uvStart + uv * uvSize) / atlasSize;
     }
 #endif
-varying vec2 vNormal;
-varying vec2 vWidth;
-varying float vGammaScale;
+varying vec4 vNormalAndWidth;
+#define vNormal vNormalAndWidth.xy
+#define vWidth vNormalAndWidth.zw
+
+#if defined(HAS_PATTERN) || defined(HAS_DASHARRAY) || defined(HAS_GRADIENT) || defined(HAS_TRAIL)
+    varying highp vec2 vGammaAndLinesofar;
+    #define vGammaScale vGammaAndLinesofar.x
+    #define vLinesofar vGammaAndLinesofar.y
+#else
+    varying float vGammaScale;
+#endif
 #ifndef ENABLE_TILE_STENCIL
     varying vec2 vPosition;
 #endif
@@ -78,9 +91,8 @@ uniform float tileExtent;
         uniform vec4 lineDashColor;
     #endif
 #endif
-#if defined(HAS_PATTERN) || defined(HAS_DASHARRAY) || defined(HAS_GRADIENT) || defined(HAS_TRAIL)
-    varying highp float vLinesofar;
-#endif
+// vLinesofar packed into vGammaAndLinesofar
+
 
 #ifdef HAS_TRAIL
     uniform float trailSpeed;

--- a/packages/vt/src/layer/plugins/painters/glsl/line.vert
+++ b/packages/vt/src/layer/plugins/painters/glsl/line.vert
@@ -38,7 +38,6 @@
 #endif
 #if defined(HAS_PATTERN) || defined(HAS_DASHARRAY) || defined(HAS_GRADIENT) || defined(HAS_TRAIL)
     attribute float aLinesofar;
-    varying highp float vLinesofar;
 #endif
 
 uniform float cameraToCenterDistance;
@@ -70,9 +69,17 @@ uniform vec2 canvasSize;
 
 uniform float layerScale;
 
-varying vec2 vNormal;
-varying vec2 vWidth;
-varying float vGammaScale;
+varying vec4 vNormalAndWidth;
+#define vNormal vNormalAndWidth.xy
+#define vWidth vNormalAndWidth.zw
+
+#if defined(HAS_PATTERN) || defined(HAS_DASHARRAY) || defined(HAS_GRADIENT) || defined(HAS_TRAIL)
+    varying highp vec2 vGammaAndLinesofar;
+    #define vGammaScale vGammaAndLinesofar.x
+    #define vLinesofar vGammaAndLinesofar.y
+#else
+    varying float vGammaScale;
+#endif
 #ifndef ENABLE_TILE_STENCIL
     varying vec2 vPosition;
 #endif
@@ -98,12 +105,14 @@ varying float vGammaScale;
             #if defined(HAS_PATTERN_ANIM) || defined(HAS_PATTERN_GAP)
                 attribute vec2 aLinePattern;
             #endif
-            #ifdef HAS_PATTERN_ANIM
-                varying float vLinePatternAnimSpeed;
-            #endif
-
-            #ifdef HAS_PATTERN_GAP
-                varying float vLinePatternGap;
+            #if defined(HAS_PATTERN_ANIM) || defined(HAS_PATTERN_GAP)
+                varying vec2 vLinePatternAnimAndGap;
+                #ifdef HAS_PATTERN_ANIM
+                    #define vLinePatternAnimSpeed vLinePatternAnimAndGap.x
+                #endif
+                #ifdef HAS_PATTERN_GAP
+                    #define vLinePatternGap vLinePatternAnimAndGap.y
+                #endif
             #endif
 
             attribute vec4 aTexInfo;

--- a/packages/vt/src/layer/plugins/painters/util/get_label_normal.js
+++ b/packages/vt/src/layer/plugins/painters/util/get_label_normal.js
@@ -21,7 +21,16 @@ export function getLabelNormal(firstCharOffset, lastCharOffset, mesh,
     vec3.copy(firstCharOffset, offset);
     offset = getCharOffset.call(this, LAST_POINT, mesh, textSize, line, lastChrIdx, projectedAnchor, anchor, scale, false);
     textMaxAngle = Math.PI * textMaxAngle / 180;
-    if (!offset || Math.abs(offset[2]) > textMaxAngle) {
+    if (!offset) {
+        return null;
+    }
+    // 计算第一个字符和最后一个字符的角度差（判断道路弯曲程度）
+    let angleDiff = Math.abs(offset[2] - firstCharOffset[2]);
+    if (angleDiff > Math.PI) {
+        angleDiff = 2 * Math.PI - angleDiff;
+    }
+    // 注意：如果是较长的文字，首尾差异可能会累积较大。如果不想受限，可以直接干掉此判断，或者结合文字长度放大这个允许阈值。
+    if (angleDiff > textMaxAngle) {
         return null;
     }
     vec3.copy(lastCharOffset, offset);


### PR DESCRIPTION
沿线道路文字修改：之前渲染上会存在可视域范围内有些道路文字不显示，即道路名称（文字沿线布置）会在特定角度下突然消失，旋转地图后又重新出 现；核心解决思路是回归 textMaxAngle 的本质：它应当限制文字顺延线段的弯曲度（相对差值），而不是限制它整体的地图朝向（绝对值)。