### PR TITLE
fix:沿线道路文字修改：之前渲染上会存在可视域范围内有些道路文字不显示，即道路名称（文字沿线布置）会在特定角度下突然消失，旋转地图后又重…

### DIFF
--- a/packages/vt/src/layer/plugins/painters/util/get_label_normal.js
+++ b/packages/vt/src/layer/plugins/painters/util/get_label_normal.js
@@ -21,7 +21,16 @@ export function getLabelNormal(firstCharOffset, lastCharOffset, mesh,
     vec3.copy(firstCharOffset, offset);
     offset = getCharOffset.call(this, LAST_POINT, mesh, textSize, line, lastChrIdx, projectedAnchor, anchor, scale, false);
     textMaxAngle = Math.PI * textMaxAngle / 180;
-    if (!offset || Math.abs(offset[2]) > textMaxAngle) {
+    if (!offset) {
+        return null;
+    }
+    // 计算第一个字符和最后一个字符的角度差（判断道路弯曲程度）
+    let angleDiff = Math.abs(offset[2] - firstCharOffset[2]);
+    if (angleDiff > Math.PI) {
+        angleDiff = 2 * Math.PI - angleDiff;
+    }
+    // 注意：如果是较长的文字，首尾差异可能会累积较大。如果不想受限，可以直接干掉此判断，或者结合文字长度放大这个允许阈值。
+    if (angleDiff > textMaxAngle) {
         return null;
     }
     vec3.copy(lastCharOffset, offset);


### PR DESCRIPTION
沿线道路文字修改：之前渲染上会存在可视域范围内有些道路文字不显示，即道路名称（文字沿线布置）会在特定角度下突然消失，旋转地图后重新出现；