### PR TITLE
fix: remove updateStyle and ensure consistency of vt tileData's styleCounter, close maptalks/issues#953

### DIFF
--- a/packages/vt/src/layer/renderer/VectorTileLayerRenderer.js
+++ b/packages/vt/src/layer/renderer/VectorTileLayerRenderer.js
@@ -101,7 +101,7 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
             if (this._workerUpdateTimeout) {
                 clearTimeout(this._workerUpdateTimeout);
             }
-            this._styles[this._styleCounter] = this.layer._getComputedStyle();
+            this._styles[this._styleCounter] = JSON.parse(JSON.stringify(this.layer._getComputedStyle()));
             this._styleCounter++;
             this._preservePrevTiles();
             if (onLoad) {
@@ -110,7 +110,7 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
                     this._groundPainter.update();
                 }
             }
-            this._styles[this._styleCounter] = this.layer._getComputedStyle();
+            this._styles[this._styleCounter] = JSON.parse(JSON.stringify(this.layer._getComputedStyle()));
             this._needRetire = true;
             // this.clear();
             // this._clearPlugin();
@@ -130,7 +130,7 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
 
     getStyleByCounter(styleCounter) {
         if (!this._styles[styleCounter] && styleCounter === this._styleCounter) {
-            this._styles[styleCounter] = this.layer._getComputedStyle();
+            this._styles[styleCounter] = JSON.parse(JSON.stringify(this.layer._getComputedStyle()));
         }
         return this._styles[styleCounter];
     }
@@ -601,7 +601,6 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
                 verticalCentimeterToPoint,
                 fetchOptions,
                 referrer,
-                style: JSON.parse(JSON.stringify(this.layer._getComputedStyle())),
                 styleCounter: this._styleCounter,
                 workerCacheIndex: this._workerCacheIndex,
                 command: 'loadTile'

--- a/packages/vt/src/layer/renderer/VectorTileLayerRenderer.js
+++ b/packages/vt/src/layer/renderer/VectorTileLayerRenderer.js
@@ -101,7 +101,7 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
             if (this._workerUpdateTimeout) {
                 clearTimeout(this._workerUpdateTimeout);
             }
-            this._styles[this._styleCounter] = JSON.parse(JSON.stringify(this.layer._getComputedStyle()));
+            this._styles[this._styleCounter] = this.layer._getComputedStyle();
             this._styleCounter++;
             this._preservePrevTiles();
             if (onLoad) {
@@ -110,7 +110,7 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
                     this._groundPainter.update();
                 }
             }
-            this._styles[this._styleCounter] = JSON.parse(JSON.stringify(this.layer._getComputedStyle()));
+            this._styles[this._styleCounter] = this.layer._getComputedStyle();
             this._needRetire = true;
             // this.clear();
             // this._clearPlugin();
@@ -130,9 +130,9 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
 
     getStyleByCounter(styleCounter) {
         if (!this._styles[styleCounter] && styleCounter === this._styleCounter) {
-            this._styles[styleCounter] = JSON.parse(JSON.stringify(this.layer._getComputedStyle()));
+            this._styles[styleCounter] = this.layer._getComputedStyle();
         }
-        return this._styles[styleCounter];
+        return JSON.parse(JSON.stringify(this._styles[styleCounter]));
     }
 
     // 为了解决阴影更新的闪烁问题，保留之前的绘制，当前数据载入后再删除

--- a/packages/vt/src/layer/renderer/VectorTileLayerRenderer.js
+++ b/packages/vt/src/layer/renderer/VectorTileLayerRenderer.js
@@ -45,6 +45,7 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
         this._workerCacheIndex = 0;
         this.ready = false;
         this._styleCounter = 1;
+        this._styles = [];
         this._requestingMVT = {};
         this._plugins = {};
         this._featurePlugins = {};
@@ -100,35 +101,22 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
             if (this._workerUpdateTimeout) {
                 clearTimeout(this._workerUpdateTimeout);
             }
-            this._workersyncing = true;
-            this._workerUpdateTimeout = setTimeout(() => {
-                if (!this.layer) {
-                    // layer is removed from map
-                    return;
+            this._styles[this._styleCounter] = this.layer._getComputedStyle();
+            this._styleCounter++;
+            this._preservePrevTiles();
+            if (onLoad) {
+                onLoad();
+                if (this._groundPainter) {
+                    this._groundPainter.update();
                 }
-                this._styleCounter++;
-                this._preservePrevTiles();
-                const style = styles || this.layer._getComputedStyle();
-                style.styleCounter = this._styleCounter;
-                this._workerConn.updateStyle(style, err => {
-                    this._workersyncing = false;
-                    if (onLoad) {
-                        onLoad();
-                        if (this._groundPainter) {
-                            this._groundPainter.update();
-                        }
-                    }
-
-                    if (err) throw new Error(err);
-                    this._needRetire = true;
-                    // this.clear();
-                    // this._clearPlugin();
-                    this._initPlugins();
-                    this.setToRedraw();
-
-                    this.layer.fire('refreshstyle');
-                });
-            }, 10);
+            }
+            this._styles[this._styleCounter] = this.layer._getComputedStyle();
+            this._needRetire = true;
+            // this.clear();
+            // this._clearPlugin();
+            this._initPlugins();
+            this.setToRedraw();
+            this.layer.fire('refreshstyle');
         } else {
             if (onLoad) {
                 onLoad();
@@ -140,24 +128,31 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
         }
     }
 
+    getStyleByCounter(styleCounter) {
+        if (!this._styles[styleCounter] && styleCounter === this._styleCounter) {
+            this._styles[styleCounter] = this.layer._getComputedStyle();
+        }
+        return this._styles[styleCounter];
+    }
+
     // 为了解决阴影更新的闪烁问题，保留之前的绘制，当前数据载入后再删除
     _preservePrevTiles() {
-        if (this._prevTilesInView) {
-            for (const p in this._prevTilesInView) {
-                const tile = this._prevTilesInView[p];
-                if (tile) {
-                    this.deleteTile(tile);
-                }
-            }
-        }
-        this._prevTilesInView = this.tilesInView;
+        // if (this._prevTilesInView) {
+        //     for (const p in this._prevTilesInView) {
+        //         const tile = this._prevTilesInView[p];
+        //         if (tile) {
+        //             this.deleteTile(tile);
+        //         }
+        //     }
+        // }
+        // this._prevTilesInView = this.tilesInView;
         const tileCache = this.tileCache;
-        for (const p in this._prevTilesInView) {
-            const tile = this._prevTilesInView[p];
-            if (tile && tile.info) {
-                tileCache.getAndRemove(tile.info.id);
-            }
-        }
+        // for (const p in this._prevTilesInView) {
+        //     const tile = this._prevTilesInView[p];
+        //     if (tile && tile.info) {
+        //         tileCache.getAndRemove(tile.info.id);
+        //     }
+        // }
         tileCache.reset();
         this.tilesInView = {};
         this.tilesLoading = {};
@@ -605,8 +600,9 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
                 centimeterToPoint,
                 verticalCentimeterToPoint,
                 fetchOptions,
-                styleCounter: this._styleCounter,
                 referrer,
+                style: JSON.parse(JSON.stringify(this.layer._getComputedStyle())),
+                styleCounter: this._styleCounter,
                 workerCacheIndex: this._workerCacheIndex,
                 command: 'loadTile'
             }
@@ -682,6 +678,10 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
         if (data && data.canceled) {
             return;
         }
+        if (data && data.styleCounter !== this._styleCounter) {
+            //返回的是上一个style的tileData
+            return;
+        }
         const layer = this.layer;
         const useDefault = layer.isDefaultRender();
         const { tiles } = this._requestingMVT[url];
@@ -705,10 +705,6 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
             return;
         }
 
-        if (data.styleCounter !== this._styleCounter) {
-            //返回的是上一个style的tileData
-            return;
-        }
         let needCompile = false;
         //restore features for plugin data
         const features = data.features;
@@ -907,7 +903,7 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
     }
 
     _getFramePlugins(tileData) {
-        const styleCounter = tileData && tileData.style;
+        const styleCounter = tileData && tileData.styleCounter;
         let plugins = this._getStylePlugins(styleCounter) || [];
         if (this.layer.isDefaultRender() && this._layerPlugins) {
             plugins = [];

--- a/packages/vt/src/layer/renderer/worker/WorkerConnection.js
+++ b/packages/vt/src/layer/renderer/worker/WorkerConnection.js
@@ -99,23 +99,6 @@ export default class WorkerConnection extends maptalks.worker.Actor {
         }
     }
 
-    updateStyle(style, cb) {
-        const layerId = this._workerLayerId;
-        const data = {
-            mapId: this._mapId,
-            layerId,
-            command: 'updateStyle',
-            params: JSON.parse(JSON.stringify(style))
-        };
-        if (this._isDedicated) {
-            if (this._dedicatedVTWorkers[layerId] !== undefined) {
-                this.send(data, null, cb, this._dedicatedVTWorkers[layerId]);
-            }
-        } else {
-            this.broadcast(data, null, cb);
-        }
-    }
-
     updateOptions(options, cb) {
         const layerId = this._workerLayerId;
         const data = {
@@ -180,6 +163,11 @@ export default class WorkerConnection extends maptalks.worker.Actor {
 
         //error, data, buffers
 
+    }
+
+    getStyleByCounter({ styleCounter }, cb) {
+        const styles = this._layer.getRenderer().getStyleByCounter(styleCounter);
+        cb(null, styles);
     }
 
     setData(geojson, cb) {

--- a/packages/vt/src/worker/Dispatcher.js
+++ b/packages/vt/src/worker/Dispatcher.js
@@ -94,14 +94,6 @@ export default class Dispatcher {
         }
     }
 
-    updateStyle({ mapId, layerId, params }, callback) {
-        const layer = this._getLayerById(mapId, layerId);
-        if (layer) {
-            layer.updateStyle(params, callback);
-            // this._resetCache();
-        }
-    }
-
     updateOptions({ mapId, layerId, params }, callback) {
         const layer = this._getLayerById(mapId, layerId);
         if (layer) {

--- a/packages/vt/src/worker/layer/BaseLayerWorker.js
+++ b/packages/vt/src/worker/layer/BaseLayerWorker.js
@@ -18,18 +18,10 @@ export default class BaseLayerWorker {
         this.id = id;
         this.options = options;
         this.upload = upload;
-        this._compileStyle(options.style);
         this.requests = {};
         this._cache = tileCache;
-        this._styleCounter = 1;
         this.loadings = tileLoading;
-    }
-
-    updateStyle(style, cb) {
-        this.options.style = style;
-        this._styleCounter = style.styleCounter;
-        this._compileStyle(style);
-        cb();
+        this._styles = [];
     }
 
     updateOptions(options, cb) {
@@ -121,46 +113,66 @@ export default class BaseLayerWorker {
     }
 
     _onTileLoad(context, cb, url, layers, features, props) {
-        this._createTileData(layers, features, context).then(data => {
-            if (data.canceled) {
-                cb(null, { canceled: true });
-                return;
-            }
-            data.data.styleCounter = context.styleCounter;
-            if (props) {
-                extend(data.data, props);
-            }
+        this._getStyleByCounter(context.styleCounter).then(compiledStyle => {
+            context.style = compiledStyle;
+            this._createTileData(layers, features, context).then(data => {
+                if (data.canceled) {
+                    cb(null, { canceled: true });
+                    return;
+                }
+                data.data.styleCounter = context.styleCounter;
+                if (props) {
+                    extend(data.data, props);
+                }
 
 
-            const features = data.data.features;
-            if (features) {
-                const newFeatures = {};
-                for (const index in features) {
-                    const feature = features[index];
-                    newFeatures[feature.id] = feature;
-                }
-                //完整的feature json 进行编码
-                const uint8Array = encodeJSON(newFeatures);
-                if (uint8Array) {
-                    data.data.featuresTypeArray = uint8Array;
-                    data.buffers = data.buffer || [];
-                    data.buffers.push(uint8Array.buffer);
-                }
-                const onlyId = this.options.features === 'id';
-                for (const index in features) {
-                    const featureData = features[index];
+                const features = data.data.features;
+                if (features) {
+                    const newFeatures = {};
+                    for (const index in features) {
+                        const feature = features[index];
+                        newFeatures[feature.id] = feature;
+                    }
+                    //完整的feature json 进行编码
+                    const uint8Array = encodeJSON(newFeatures);
                     if (uint8Array) {
-                        //删除geometry,已经包含在featuresTypeArray
-                        delete featureData.geometry;
+                        data.data.featuresTypeArray = uint8Array;
+                        data.buffers = data.buffer || [];
+                        data.buffers.push(uint8Array.buffer);
                     }
-                    if (onlyId) {
-                        features[index] = featureData.id;
+                    const onlyId = this.options.features === 'id';
+                    for (const index in features) {
+                        const featureData = features[index];
+                        if (uint8Array) {
+                            //删除geometry,已经包含在featuresTypeArray
+                            delete featureData.geometry;
+                        }
+                        if (onlyId) {
+                            features[index] = featureData.id;
+                        }
                     }
                 }
-            }
-            cb(null, data.data, data.buffers);
-        }).catch(err => {
-            cb(err);
+                cb(null, data.data, data.buffers);
+            }).catch(err => {
+                cb(err);
+            });
+        });
+    }
+
+    _getStyleByCounter(styleCounter) {
+        if (this._styles[styleCounter]) {
+            return Promise.resolve(this._styles[styleCounter]);
+        }
+        return new Promise((resolve, reject) => {
+            this.upload('getStyleByCounter', { styleCounter }, null, (err, data) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                const compiledStyle = this._styles[styleCounter] = this._compileStyle(data);
+                compiledStyle.style = data;
+                resolve(compiledStyle);
+            });
         });
     }
 
@@ -270,14 +282,16 @@ export default class BaseLayerWorker {
             });
         }
         const { glScale, tileInfo } = context;
-        const useDefault = !this.options.style.style.length && !this.options.style.featureStyle.length;
-        let pluginConfigs = this.pluginConfig.slice(0);
+        const { pluginConfigs: stylePlugins, featurePlugins, styledFeatures } = context.style;
+        const style = context.style.style;
+        const useDefault = !style.style.length && !style.featureStyle.length;
+        let pluginConfigs = stylePlugins.slice(0);
         if (useDefault) {
             //图层没有定义任何style，通过数据动态生成pluginConfig
             pluginConfigs = this._updateLayerPluginConfig(layers);
         }
-        if (this.featurePlugins) {
-            pushIn(pluginConfigs, this.featurePlugins);
+        if (featurePlugins) {
+            pushIn(pluginConfigs, featurePlugins);
         }
         const allCustomProps = {};
         for (let i = 0; i < pluginConfigs.length; i++) {
@@ -348,7 +362,7 @@ export default class BaseLayerWorker {
             getFnTypeProps(pluginConfig.symbol, fnTypeProps, i);
             hasFnTypeProps = hasFnTypeProps || fnTypeProps[i] && fnTypeProps[i].size > 0;
 
-            const { tileFeatures, tileFeaIndexes } = this._filterFeatures(zoom, pluginConfig.type, pluginConfig.filter, features, feaTags, i);
+            const { tileFeatures, tileFeaIndexes } = this._filterFeatures(styledFeatures, zoom, pluginConfig.type, pluginConfig.filter, features, feaTags, i);
 
             if (!tileFeatures.length) {
                 targetData[typeIndex] = null;
@@ -400,9 +414,6 @@ export default class BaseLayerWorker {
         }
 
         return Promise.all(promises).then(([styleCounter, ...tileDatas]) => {
-            if (styleCounter !== this._styleCounter) {
-                return { canceled: true };
-            }
             function handleTileData(tileData, i) {
                 if (tileData.data.ref !== undefined) {
                     return;
@@ -697,13 +708,13 @@ export default class BaseLayerWorker {
      * @param {*} filter
      * @param {*} features
      */
-    _filterFeatures(zoom, styleType, filter, features, tags, index) {
+    _filterFeatures(styledFeatures, zoom, styleType, filter, features, tags, index) {
         const keyName = (KEY_IDX + '').trim();
         const indexes = [];
         const filtered = [];
         const l = features.length;
         for (let i = 0; i < l; i++) {
-            if (styleType !== 1 && features[i].id !== undefined && this.styledFeatures[features[i].id]) {
+            if (styleType !== 1 && features[i].id !== undefined && styledFeatures[features[i].id]) {
                 continue;
             }
 
@@ -767,10 +778,7 @@ export default class BaseLayerWorker {
                 featurePlugins.push(compiledFeatureStyle[i]);
             }
         }
-
-        this.pluginConfig = pluginConfigs;
-        this.featurePlugins = featurePlugins;
-        this.styledFeatures = styledFeatures;
+        return { pluginConfigs, featurePlugins, styledFeatures };
     }
 
     _updateLayerPluginConfig(layers) {

--- a/packages/vt/src/worker/layer/BaseLayerWorker.js
+++ b/packages/vt/src/worker/layer/BaseLayerWorker.js
@@ -161,19 +161,21 @@ export default class BaseLayerWorker {
 
     _getStyleByCounter(styleCounter) {
         if (this._styles[styleCounter]) {
-            return Promise.resolve(this._styles[styleCounter]);
+            return this._styles[styleCounter];
         }
-        return new Promise((resolve, reject) => {
+        this._styles[styleCounter] = new Promise((resolve, reject) => {
             this.upload('getStyleByCounter', { styleCounter }, null, (err, data) => {
                 if (err) {
                     reject(err);
                     return;
                 }
-                const compiledStyle = this._styles[styleCounter] = this._compileStyle(data);
+                const compiledStyle = this._compileStyle(data);
                 compiledStyle.style = data;
+                this._styles[styleCounter] = Promise.resolve(compiledStyle);
                 resolve(compiledStyle);
             });
         });
+        return this._styles[styleCounter];
     }
 
     abortTile(url, cb) {

--- a/packages/vt/test/specs/update.spec.js
+++ b/packages/vt/test/specs/update.spec.js
@@ -725,7 +725,7 @@ describe('update style specs', () => {
         assertChangeStyle(done, [0, 0, 255, 255], layer => {
             layer.updateSymbol(1, { visible: true });
             assert(layer.options.style[1].symbol.visible === true);
-        }, true, style, 0, 7);
+        }, true, style, 0, 6);
     });
 
     it('should can set visible of multiple symbol', done => {
@@ -2037,7 +2037,7 @@ describe('update style specs', () => {
         layer.once('pluginsinited', () => {
             layer.updateDataConfig(0, { foo2: 2 });
             layer.updateDataConfig('squarePoint', { foo3: 2 });
-            assert.equal(refreshCount, 0);
+            assert.equal(refreshCount, 2);
             assert.deepStrictEqual(layer.options.style[0].renderPlugin.dataConfig, layer.getComputedStyle().style[0].renderPlugin.dataConfig);
             assert.deepStrictEqual(layer.getStyle()[0].renderPlugin.dataConfig, layer.getComputedStyle().style[0].renderPlugin.dataConfig);
             assert.deepStrictEqual(layer.options.style[0].renderPlugin.dataConfig, { type: 'native-point', foo2: 2 });
@@ -2569,10 +2569,12 @@ describe('update style specs', () => {
 
         if (isListenToRefreshStyle) {
             layer.once('refreshstyle', () => {
-                const pixel = readPixel(layer.getRenderer().canvas, x / 2, y / 2);
-                //变成绿色
-                assert.deepEqual(pixel, expectedColor);
-                done();
+                setTimeout(() => {
+                    const pixel = readPixel(layer.getRenderer().canvas, x / 2, y / 2);
+                    //变成绿色
+                    assert.deepEqual(pixel, expectedColor);
+                    done();
+                }, 100);
             });
         }
         layer.addTo(map);


### PR DESCRIPTION
### 解决的问题：

解决图层样式计数和worker样式计数不一致，造成的瓦片数据被错误样式渲染

### 原有逻辑
1. 图层会维护样式计数，每次style更新时会增加计数。
2. 更新style时，图层会调用renderer.updateStyle，把新的样式和计数广播给所有worker
3. worker对应的updateStyle逻辑中，会增加计数并保存新的样式到 this.pluginConfig 和 this.featurePlugins 中
4. 待所有worker收到新的计数后，主线程同步设置新的样式计数
5. worker返回的瓦片数据中会附带瓦片计数，和图层计数不同的瓦片数据会被忽略‘

但上述过程中，会存在主线程样式计数与worker不同步的情况，导致 maptalks/issues#953 的出现

### 修改后逻辑
1. 样式计数仍由图层维护，每次style更新时会增加计数。
2. 更新style后，图层会马上给计数加一，且不再通知worker
3. 图层请求瓦片时，会把当前的样式计数附在参数中告知worker
5. worker如果发现样式计数不一致，从图层获得新计数对应的样式后，再解析数据