### PR TITLE
fix: Adapt to lower versions of webpack

### DIFF
--- a/packages/gltf-loader/src/GLTFLoader.js
+++ b/packages/gltf-loader/src/GLTFLoader.js
@@ -70,7 +70,7 @@ export default class GLTFLoader {
         if (!extensions || !extensions['KHR_techniques_webgl']) {
             return Promise.resolve(extensions);
         }
-        return this._accessor.requestKHRTechniquesWebgl(extensions['KHR_techniques_webgl']).then(extension  => {
+        return this._accessor.requestKHRTechniquesWebgl(extensions['KHR_techniques_webgl']).then(extension => {
             extensions['KHR_techniques_webgl'] = extension;
             return extensions;
         });
@@ -309,12 +309,12 @@ export default class GLTFLoader {
             const gltf = {
                 textures: this.gltf.textures,
                 asset: this.gltf.asset,
-                scene : defaultScene,
-                scenes : scenes,
-                nodes : nodeMap,
-                meshes : this.meshes,
+                scene: defaultScene,
+                scenes: scenes,
+                nodes: nodeMap,
+                meshes: this.meshes,
                 materials: this.gltf.materials,
-                skins : this.skins,
+                skins: this.skins,
                 extensionsRequired: this.gltf.extensionsRequired,
                 extensionsUsed: this.gltf.extensionsUsed
             };
@@ -357,7 +357,7 @@ export default class GLTFLoader {
                     instancingPromises.push(loadPromise);
                 }
             }, 'nodes');
-            
+
             // Wait for all GPU instancing data to finish loading
             return Promise.all(instancingPromises).then(() => nodes);
         });
@@ -630,7 +630,7 @@ export default class GLTFLoader {
                 return accumulator;
             }, {});
             const primitive = {
-                attributes : attrData,
+                attributes: attrData,
                 material: primJSON.material
             };
             if (indices) primitive.indices = indices;
@@ -665,11 +665,19 @@ export default class GLTFLoader {
 
         // Load buffer views required for structural metadata
         if (hasStructuralMetadata) {
-            const ext = this.gltf.extensions?.[EXT_STRUCTURAL_METADATA];
-            if (ext?.propertyTables) {
-                promises.push(
-                    this._loadPropertyTableBuffers(ext.propertyTables),
-                );
+            // const ext = this.gltf.extensions?.[EXT_STRUCTURAL_METADATA];
+            // if (ext?.propertyTables) {
+            //     promises.push(
+            //         this._loadPropertyTableBuffers(ext.propertyTables),
+            //     );
+            // }
+            if (this.gltf.extensions && this.gltf.extensions[EXT_STRUCTURAL_METADATA]) {
+                const ext = this.gltf.extensions[EXT_STRUCTURAL_METADATA];
+                if (ext.propertyTables) {
+                    promises.push(
+                        this._loadPropertyTableBuffers(ext.propertyTables),
+                    );
+                }
             }
         }
 
@@ -749,7 +757,7 @@ function requestImage(url, fetchOptions, cb) {
         ctx.drawImage(image, 0, 0, image.width, image.height);
         const imgData = ctx.getImageData(0, 0, image.width, image.height);
         //TODO, retina may need special operations
-        const result = { width : image.width, height : image.height, data : new Uint8Array(imgData.data) };
+        const result = { width: image.width, height: image.height, data: new Uint8Array(imgData.data) };
         cb(null, result);
     };
     image.onerror = function (err) {
@@ -758,7 +766,7 @@ function requestImage(url, fetchOptions, cb) {
     image.src = url;
 }
 
-function fetchSchema(url, fetchOptions,urlModifier) {
+function fetchSchema(url, fetchOptions, urlModifier) {
     return Ajax.getJSON(url, fetchOptions, urlModifier);
 }
 
@@ -783,7 +791,7 @@ function requestImageOffscreen(url, fetchOptions, cb) {
         const data = url;
         const blob = new Blob([data]);
         promise = createImageBitmap(blob);
-        promise.then(thenMethod.bind(this)).then(res =>{
+        promise.then(thenMethod.bind(this)).then(res => {
             cb(null, res);
         }).catch(err => {
             console.warn(err);
@@ -806,7 +814,7 @@ function loopRequests() {
             // 2022-03-09
             const blob = new Blob([new Uint8Array(arrayBuffer)]);
             return createImageBitmap(blob);
-        }).then(thenMethod.bind(context)).then(res =>{
+        }).then(thenMethod.bind(context)).then(res => {
             cb.call(context, null, res);
             const index = workingRequests.indexOf(request);
             workingRequests.splice(index, 1);

--- a/packages/gltf-loader/src/extensions/ExtMeshFeatures.js
+++ b/packages/gltf-loader/src/extensions/ExtMeshFeatures.js
@@ -9,7 +9,10 @@ export const EXT_MESH_FEATURES = 'EXT_mesh_features';
  * @returns {Object|undefined} Extension data
  */
 export function getMeshFeaturesExtension(primJSON) {
-    return primJSON?.extensions?.[EXT_MESH_FEATURES];
+    // return primJSON?.extensions?.[EXT_MESH_FEATURES];
+    if (primJSON.extensions) {
+        return primJSON.extensions[EXT_MESH_FEATURES];
+    }
 }
 
 /**

--- a/packages/gltf-loader/src/extensions/ExtMeshGpuInstancing.js
+++ b/packages/gltf-loader/src/extensions/ExtMeshGpuInstancing.js
@@ -9,7 +9,11 @@ export const EXT_MESH_GPU_INSTANCING = 'EXT_mesh_gpu_instancing';
  * @returns {Object|undefined} Extension data
  */
 export function getGpuInstancingExtension(nodeJSON) {
-    return nodeJSON?.extensions?.[EXT_MESH_GPU_INSTANCING];
+    // return nodeJSON?.extensions?.[EXT_MESH_GPU_INSTANCING];
+    if (nodeJSON.extensions) {
+        return nodeJSON.extensions[EXT_MESH_GPU_INSTANCING];
+    }
+    return null;
 }
 
 /**
@@ -18,9 +22,12 @@ export function getGpuInstancingExtension(nodeJSON) {
  * @returns {Array<{name: string, accessorIndex: number}>} Array of accessor information
  */
 export function collectInstancingAccessors(instancingExt) {
-    if (!instancingExt?.attributes) {
+    if (!instancingExt || !instancingExt.attributes) {
         return [];
     }
+    // if (!instancingExt?.attributes) {
+    //     return [];
+    // }
 
     return Object.entries(instancingExt.attributes).map(([name, accessorIndex]) => ({
         name,

--- a/packages/gltf-loader/src/extensions/ExtStructuralMetadata.js
+++ b/packages/gltf-loader/src/extensions/ExtStructuralMetadata.js
@@ -15,10 +15,14 @@ export const EXT_STRUCTURAL_METADATA = 'EXT_structural_metadata';
  * @returns {Promise<Object|null>} Extension data, including schema, propertyTables, buffers
  */
 export async function getStructuralMetadataData(gltf, buffers, rootPath, fetchOptions, urlModifier, fetchSchema) {
-    const ext = gltf?.extensions?.[EXT_STRUCTURAL_METADATA];
-    if (!ext) {
+    // const ext = gltf?.extensions?.[EXT_STRUCTURAL_METADATA];
+    // if (!ext) {
+    //     return null;
+    // }
+    if (!gltf || !gltf.extensions || !gltf.extensions[EXT_STRUCTURAL_METADATA]) {
         return null;
     }
+    const ext = gltf.extensions[EXT_STRUCTURAL_METADATA];
 
     // If schemaUri exists, request external schema
     if (ext.schemaUri) {

--- a/packages/layer-3dtiles/rollup.config.js
+++ b/packages/layer-3dtiles/rollup.config.js
@@ -27,6 +27,11 @@ const plugins = [].concat(production ? [
     })
 ] : []);
 
+const esPlugins = [].concat(production ? [
+    removeGlobal(),
+
+] : []);
+
 //worker.js中的global可能被webpack替换为全局变量，造成worker代码执行失败，所以这里统一把typeof global替换为typeof undefined
 function removeGlobal() {
     return {
@@ -156,7 +161,7 @@ module.exports = [
                 ignoreGlobal: true
             }),
             glsl(),
-            typescript({ tsconfig: './tsconfig.json', sourceMap: true } )
+            typescript({ tsconfig: './tsconfig.json', sourceMap: true })
         ].concat(plugins),
         external: ['maptalks', '@maptalks/gl'],
         output: {
@@ -201,8 +206,8 @@ if (production) {
                     ignoreGlobal: true
                 }),
                 glsl(),
-                typescript({ tsconfig: './tsconfig.json'} )
-            ].concat(plugins),
+                typescript({ tsconfig: './tsconfig.json' })
+            ].concat(esPlugins),
             output: {
                 globals: {
                     'maptalks': 'maptalks',


### PR DESCRIPTION
fix https://github.com/maptalks/maptalks.js/issues/2874

错误分析:

- gltf-loader里使用了高级的语法 `?.`,导致低版本的webpack识别不了，例如老的vue-cli(webpack 3.x)
- 当用户开启babel 对maptalks转义后,导致worker里的cLass语法被转义，babel会创建 工具函数 `_createClass`,这个私有函数会被提取到顶层（主线程里）,而worker线程里的class 被转义成了 `_createClass` 的形式，从而找不到 `_createClass` 函数了

注意：

worker的代码要使用字符串，不要使用函数等，函数会被二次打包转义掉，字符串是`worker code`属于值，不属于语法，这样就可以避免被转义