### PR TITLE
添加Spider Marker，实现同一地理位置有很多点位时，点击可以螺旋散开显示

### DIFF
--- a/packages/maptalks/src/layer/VectorLayer.ts
+++ b/packages/maptalks/src/layer/VectorLayer.ts
@@ -96,6 +96,14 @@ class VectorLayer extends OverlayLayer {
         super(id, geometries, options);
     }
 
+    onAdd() {
+        super.onAdd();
+    }
+
+    onRemove() {
+        super.onRemove();
+    }
+
     onConfig(conf: Record<string, any>) {
         super.onConfig(conf);
         if (!isNil(conf['enableAltitude'])) {
@@ -368,6 +376,358 @@ class VectorLayer extends OverlayLayer {
     static getCollectionPainterClass() {
         return CollectionPainter;
     }
+
+    // ==================== Spider Marker Methods ====================
+    // 蛛网标记：解决多个 POI 坐标相同时的重叠问题。
+    // 相同坐标的多个点位只显示一个堆叠标记，点击后螺旋散开显示全部点位。
+    // 使用方式：addSpiderMarker() 添加标记，点击堆叠标记展开，点击空白处折叠。
+
+    //@internal
+    _spiderCoordGroups: Map<string, any[]> = new Map();        // 按坐标分组的点位数据
+    //@internal
+    _spiderStackMarkers: Map<string, { marker: Marker }> = new Map();  // 堆叠标记引用
+    //@internal
+    _spiderExpandedMarkers: Marker[] = [];   // 当前展开的标记
+    //@internal
+    _spiderExpandedLines: LineString[] = [];  // 当前展开的连接线
+    //@internal
+    _spiderActiveCoord: string | null = null;  // 当前展开的坐标
+
+    /**
+     * 批量设置蛛网标记数据
+     * @english
+     * Set marker data for spider display. Markers with same coordinates will be stacked.
+     *
+     * @param data - Array of marker data
+     * @param options - Spider options
+     * @param options.spiderRadius - Expansion radius in pixels
+     * @param options.spiderLineColor - Line color between stacked markers
+     * @param options.defaultMarkerSymbol - Default symbol for markers
+     * @param options.stackSymbol - Symbol for stack indicator
+     * @param options.onSpiderMarkerClick - Callback when clicking an expanded marker
+     */
+    setSpiderData(data: any[], options?: SpiderOptions): this {
+        options = options || {};
+        const spiderRadius = options['spiderRadius'] || 60;
+        const spiderLineColor = options['spiderLineColor'] || '#DE3333';
+        const defaultMarkerSymbol = options['markerSymbol'] || null;
+        const onSpiderMarkerClick = options['onSpiderMarkerClick'];
+
+        // Store options for later use
+        (this as any)._spiderOptions = { spiderRadius, spiderLineColor, defaultMarkerSymbol, onSpiderMarkerClick };
+
+        // Clear existing spider markers
+        this._clearSpider();
+
+        // Group by coordinate
+        this._spiderCoordGroups.clear();
+        data.forEach(item => {
+            const key = this._coordKey(item.coord);
+            if (!this._spiderCoordGroups.has(key)) {
+                this._spiderCoordGroups.set(key, []);
+            }
+            const group = this._spiderCoordGroups.get(key);
+            if (group) {
+                group.push(item);
+            }
+        });
+
+        // Render - 只显示一个 marker，不显示数量
+        this._spiderCoordGroups.forEach((group, key) => {
+            const coord = group[0].coord;
+            // 使用第一个 item 的 symbol 或默认样式，堆叠时用 stackSymbol
+            const itemSymbol = group[0].symbol || defaultMarkerSymbol || {
+                markerType: 'ellipse',
+                markerWidth: 30,
+                markerHeight: 30,
+                markerFill: '#4CAF50'
+            };
+            const marker = new Marker(coord, {
+                id: group[0].id,
+                symbol: itemSymbol as any
+            });
+
+            if (group.length > 1) {
+                // 有多个点位重叠，使用 stackSymbol
+                const stackSymbol = (this as any)._spiderOptions?.stackSymbol || itemSymbol;
+                marker.setSymbol(stackSymbol as any);
+                (marker as any)._isSpiderStack = true;
+                (marker as any)._spiderGroup = group;
+                (marker as any)._spiderKey = key;
+                (marker as any)._spiderCoord = coord;
+                this._spiderStackMarkers.set(key, { marker });
+            } else {
+                // 只有一个点位
+                (marker as any)._spiderItem = group[0];
+            }
+
+            this.addGeometry(marker);
+        });
+
+        return this;
+    }
+
+    /**
+     * 添加单个蛛网标记（用法与 addMarker 一致）
+     * @english
+     * Add a single marker. If multiple markers share the same coordinate, they will be
+     * automatically stacked and expandable.
+     *
+     * @param item - Marker data
+     * @param options - Spider options (only effective on first marker at a coordinate)
+     */
+    addSpiderMarker(item: any, options?: SpiderOptions): this {
+        // Merge options from first call
+        if (options) {
+            const opts = (this as any)._spiderOptions || {};
+            if (!opts.spiderRadius) {
+                opts.spiderRadius = options['spiderRadius'] || 60;
+                opts.spiderLineColor = options['spiderLineColor'] || '#DE3333';
+                opts.defaultMarkerSymbol = options['markerSymbol'] || null;
+                opts.onSpiderMarkerClick = options['onSpiderMarkerClick'];
+                (this as any)._spiderOptions = opts;
+            }
+        }
+
+        const key = this._coordKey(item.coord);
+        const existingGroup = this._spiderCoordGroups.get(key);
+
+        if (!existingGroup) {
+            // First marker at this coordinate
+            this._spiderCoordGroups.set(key, [item]);
+
+            // Create the marker - use item.symbol, or defaultMarkerSymbol from options, or fallback
+            const opts = (this as any)._spiderOptions || {};
+            const itemSymbol = item.symbol || opts.defaultMarkerSymbol || {
+                markerType: 'ellipse',
+                markerWidth: 30,
+                markerHeight: 30,
+                markerFill: '#4CAF50'
+            };
+            const marker = new Marker(item.coord, {
+                id: item.id,
+                symbol: itemSymbol as any
+            });
+            (marker as any)._spiderItem = item;
+            this.addGeometry(marker);
+            this._spiderStackMarkers.set(key, { marker });
+
+        } else {
+            // Already has marker(s) at this coordinate
+            existingGroup.push(item);
+
+            // Check if we need to convert to stack
+            if (existingGroup.length === 2) {
+                // Was a single marker, now need stack
+                const stack = this._spiderStackMarkers.get(key);
+                if (stack) {
+                    const group = existingGroup;
+                    const coord = group[0].coord;
+
+                    // Use stackSymbol if provided (from options or stored options), otherwise use first item's symbol
+                    const opts = (this as any)._spiderOptions || {};
+                    const stackSymbol = (options && options['stackSymbol']) || opts.stackSymbol || group[0].symbol || {
+                        markerType: 'ellipse',
+                        markerWidth: 36,
+                        markerHeight: 36,
+                        markerFill: '#FF5722',
+                        markerLineColor: '#fff',
+                        markerLineWidth: 2
+                    };
+
+                    // Update marker to be a stack
+                    stack.marker.setSymbol(stackSymbol as any);
+                    (stack.marker as any)._isSpiderStack = true;
+                    (stack.marker as any)._spiderGroup = group;
+                    (stack.marker as any)._spiderKey = key;
+                    (stack.marker as any)._spiderCoord = coord;
+                    delete (stack.marker as any)._spiderItem;
+                }
+            } else {
+                // Already a stack, just update the group reference
+                const stack = this._spiderStackMarkers.get(key);
+                if (stack) {
+                    (stack.marker as any)._spiderGroup = existingGroup;
+                }
+            }
+        }
+
+        return this;
+    }
+
+    /**
+     * 处理堆叠标记点击，展开或折叠
+     * @param coordinate - 被点击的坐标
+     * @returns 是否处理了点击事件
+     */
+    handleSpiderClick(coordinate: number[]): boolean {
+        const coordKey = this._coordKey(coordinate);
+        const group = this._spiderCoordGroups.get(coordKey);
+        if (!group || group.length <= 1) {
+            return false;
+        }
+
+        const opts = (this as any)._spiderOptions || {};
+        const { spiderRadius, spiderLineColor, defaultMarkerSymbol } = opts;
+
+        const isExpanded = this._spiderActiveCoord === coordKey;
+        if (isExpanded) {
+            // Collapse
+            this._collapseSpider();
+            return true;
+        }
+
+        // Collapse any other first
+        this._collapseSpider();
+
+        // Expand this one
+        const positions = this._getSpiderPositions(coordinate, group.length, spiderRadius || 60);
+
+        // Create lines
+        group.forEach((item, i) => {
+            const line = new LineString([coordinate, positions[i]], {
+                symbol: {
+                    lineColor: spiderLineColor || '#DE3333',
+                    lineWidth: 2,
+                    lineOpacity: 0.6
+                } as any
+            });
+            this._spiderExpandedLines.push(line);
+            this.addGeometry(line);
+        });
+
+        // Create expanded markers - 使用每个 item 自己的 symbol
+        group.forEach((item, i) => {
+            const itemSymbol = item.symbol || defaultMarkerSymbol || {
+                markerType: 'ellipse',
+                markerWidth: 30,
+                markerHeight: 30,
+                markerFill: '#4CAF50',
+                markerLineColor: '#fff',
+                markerLineWidth: 2
+            };
+            const marker = new Marker(positions[i], {
+                id: 'spider_' + item.id,
+                symbol: itemSymbol as any
+            });
+            (marker as any)._spiderItem = item;
+            (marker as any)._spiderParentKey = coordKey;
+
+            this._spiderExpandedMarkers.push(marker);
+            this.addGeometry(marker);
+        });
+
+        // Hide stack
+        const stack = this._spiderStackMarkers.get(coordKey);
+        if (stack) {
+            stack.marker.hide();
+        }
+
+        this._spiderActiveCoord = coordKey;
+
+        return true;
+    }
+
+    /**
+     * 处理展开后标记的点击，显示详情
+     * @param marker - 被点击的标记
+     */
+    handleExpandedMarkerClick(marker: Marker): void {
+        const opts = (this as any)._spiderOptions || {};
+        const { onSpiderMarkerClick } = opts;
+        const item = (marker as any)._spiderItem;
+        if (item && onSpiderMarkerClick) {
+            onSpiderMarkerClick(item);
+        }
+    }
+
+    /**
+     * 折叠当前展开的蛛网
+     */
+    collapseSpider(): void {
+        this._collapseSpider();
+    }
+
+    //@internal
+    private _coordKey(coord: number[]): string {
+        return `${coord[0].toFixed(6)},${coord[1].toFixed(6)}`;
+    }
+
+    //@internal
+    private _clearSpider(): void {
+        this._collapseSpider();
+        this._spiderStackMarkers.forEach((stack) => {
+            this.removeGeometry(stack.marker);
+        });
+        this._spiderStackMarkers.clear();
+        this._spiderCoordGroups.clear();
+    }
+
+    //@internal
+    private _collapseSpider(): void {
+        if (!this._spiderActiveCoord) return;
+
+        this._spiderExpandedMarkers.forEach(m => {
+            this.removeGeometry(m);
+            m.remove();
+        });
+        this._spiderExpandedMarkers = [];
+
+        this._spiderExpandedLines.forEach(l => {
+            this.removeGeometry(l);
+            l.remove();
+        });
+        this._spiderExpandedLines = [];
+
+        const stack = this._spiderStackMarkers.get(this._spiderActiveCoord);
+        if (stack) {
+            stack.marker.show();
+            (stack.marker as any)._spiderExpanded = false;
+        }
+
+        this._spiderActiveCoord = null;
+    }
+
+    //@internal
+    // 计算螺旋散开位置，使用黄金角度（37.5°）实现均匀分布
+    private _getSpiderPositions(center: number[], count: number, radius: number): number[][] {
+        const positions: number[][] = [];
+
+        if (count === 1) {
+            return [center];
+        }
+
+        const map = this.getMap();
+        if (!map) {
+            return [center];
+        }
+
+        const centerCoord = new Coordinate(center[0], center[1]);
+        const centerPoint = map.coordToContainerPoint(centerCoord);
+
+        // 螺旋状散开
+        const angleStep = 37.5; // 黄金角度，螺旋排列
+        let r = radius * 0.5;
+
+        for (let i = 0; i < count; i++) {
+            const angle = (i * angleStep) * Math.PI / 180;
+            r = radius * 0.3 + (i * radius * 0.15); // 逐渐增大半径
+            const px = centerPoint.x + r * Math.cos(angle);
+            const py = centerPoint.y + r * Math.sin(angle);
+            const coord = map.containerPointToCoord(new Point(px, py));
+            positions.push([coord.x, coord.y]);
+        }
+
+        return positions;
+    }
+}
+
+interface SpiderOptions {
+    spiderRadius?: number;
+    spiderLineColor?: string;
+    markerSymbol?: any;
+    stackSymbol?: any;
+    onSpiderMarkerClick?: (item: any) => void;
 }
 
 VectorLayer.mergeOptions(options);

--- a/packages/maptalks/src/layer/VectorLayer.ts
+++ b/packages/maptalks/src/layer/VectorLayer.ts
@@ -468,24 +468,55 @@ class VectorLayer extends OverlayLayer {
     }
 
     /**
-     * 添加单个蛛网标记（用法与 addMarker 一致）
+     * 添加单个蛛网标记
      * @english
      * Add a single marker. If multiple markers share the same coordinate, they will be
      * automatically stacked and expandable.
      *
-     * @param item - Marker data
+     * @param coord - Coordinate array [lng, lat] or properties object
+     * @param properties - Marker properties { id, name, symbol, ... } (if first param is coord)
      * @param options - Spider options (only effective on first marker at a coordinate)
+     *
+     * @example
+     * // 方式1：坐标在前，属性在后（推荐）
+     * vectorLayer.addSpiderMarker([121.507, 31.247], {
+     *   id: 1,
+     *   name: 'Coffee Shop',
+     *   symbol: { markerFile: './marker.png', markerWidth: 32, markerHeight: 32 }
+     * });
+     *
+     * // 方式2：直接传对象（兼容旧版）
+     * vectorLayer.addSpiderMarker({
+     *   id: 2,
+     *   coord: [121.508, 31.248],
+     *   name: 'Tea House'
+     * });
      */
-    addSpiderMarker(item: any, options?: SpiderOptions): this {
-        // Merge options from first call
-        if (options) {
-            const opts = (this as any)._spiderOptions || {};
-            if (!opts.spiderRadius) {
-                opts.spiderRadius = options['spiderRadius'] || 60;
-                opts.spiderLineColor = options['spiderLineColor'] || '#DE3333';
-                opts.defaultMarkerSymbol = options['markerSymbol'] || null;
-                opts.onSpiderMarkerClick = options['onSpiderMarkerClick'];
-                (this as any)._spiderOptions = opts;
+    addSpiderMarker(coord: number[] | any, properties?: any, options?: SpiderOptions): this {
+        // 判断是旧版格式 { coord, ... } 还是新版格式 [lng, lat], { ... }
+        let item: any;
+        let opts = options;
+
+        if (Array.isArray(coord)) {
+            // 新版格式：坐标在前
+            item = properties || {};
+            item.coord = coord;
+        } else {
+            // 旧版格式：直接是对象
+            item = coord;
+            opts = properties;
+        }
+
+        // Merge spider options from first call
+        if (opts) {
+            const spiderOpts = (this as any)._spiderOptions || {};
+            if (!spiderOpts.spiderRadius) {
+                spiderOpts.spiderRadius = opts['spiderRadius'] || 60;
+                spiderOpts.spiderLineColor = opts['spiderLineColor'] || '#DE3333';
+                spiderOpts.defaultMarkerSymbol = opts['markerSymbol'] || null;
+                spiderOpts.stackSymbol = opts['stackSymbol'] || null;
+                spiderOpts.onSpiderMarkerClick = opts['onSpiderMarkerClick'];
+                (this as any)._spiderOptions = spiderOpts;
             }
         }
 
@@ -496,9 +527,9 @@ class VectorLayer extends OverlayLayer {
             // First marker at this coordinate
             this._spiderCoordGroups.set(key, [item]);
 
-            // Create the marker - use item.symbol, or defaultMarkerSymbol from options, or fallback
-            const opts = (this as any)._spiderOptions || {};
-            const itemSymbol = item.symbol || opts.defaultMarkerSymbol || {
+            // Create the marker
+            const spiderOpts = (this as any)._spiderOptions || {};
+            const itemSymbol = item.symbol || spiderOpts.defaultMarkerSymbol || {
                 markerType: 'ellipse',
                 markerWidth: 30,
                 markerHeight: 30,
@@ -524,9 +555,9 @@ class VectorLayer extends OverlayLayer {
                     const group = existingGroup;
                     const coord = group[0].coord;
 
-                    // Use stackSymbol if provided (from options or stored options), otherwise use first item's symbol
-                    const opts = (this as any)._spiderOptions || {};
-                    const stackSymbol = (options && options['stackSymbol']) || opts.stackSymbol || group[0].symbol || {
+                    // Use stackSymbol if provided
+                    const spiderOpts = (this as any)._spiderOptions || {};
+                    const stackSymbol = (opts && opts['stackSymbol']) || spiderOpts.stackSymbol || group[0].symbol || {
                         markerType: 'ellipse',
                         markerWidth: 36,
                         markerHeight: 36,


### PR DESCRIPTION
当地图上多个 POI 点位具有相同的地理坐标时（如商场内多个店铺、同一建筑内的多个公司），普通显示会出现完全重叠的
问题，导致只能看到最上层的标记，其他点位被遮挡。

  蛛网标记（Spider Marker） 功能通过以下方式解决：

  - 堆叠显示：相同坐标的多个点位只显示一个特殊标记
  - 点击展开：点击堆叠标记后，所有点位以螺旋状散开显示
  - 连接线：展开时用线条连接原始位置和散开位置
  - 点击详情：点击散开后任意标记可查看该点位详情
  - 折叠收起：再次点击堆叠标记或点击空白处收起