### PR TITLE
fix: set terrain texture size to tileSize to reduce memory

### DIFF
--- a/packages/gl/src/layer/terrain/TerrainLayer.js
+++ b/packages/gl/src/layer/terrain/TerrainLayer.js
@@ -38,7 +38,8 @@ const options = {
     'exaggeration': 1,
     'errorScale': 1,
     'hasSkirts': true,
-    'colors': []
+    'colors': [],
+    'skinScale': 1
 };
 
 const EMPTY_TILE_GRIDS = {

--- a/packages/gl/src/layer/terrain/TerrainLayerRenderer.js
+++ b/packages/gl/src/layer/terrain/TerrainLayerRenderer.js
@@ -810,9 +810,10 @@ class TerrainLayerRenderer extends MaskRendererMixin(TileLayerRendererable(Layer
 
     _createTerrainSkinTexture() {
         const tileSize = this.layer.getTileSize().width;
+        const skinScale = this.layer.options.skinScale;
         // 乘以2是为了瓦片（缩放时）被放大后保持清晰度
-        const width = tileSize;
-        const height = tileSize;
+        const width = tileSize * skinScale;
+        const height = tileSize * skinScale;
         const regl = this.device;
 
         const color = regl.texture({
@@ -1574,6 +1575,7 @@ class TerrainLayerRenderer extends MaskRendererMixin(TileLayerRendererable(Layer
         }
 
         const tileSize = this.layer.getTileSize().width;
+        const skinScale = this.layer.options.skinScale;
         this._skinShader = new reshader.MeshShader({
             name: 'terrain-skin',
             vert: skinVert,
@@ -1587,8 +1589,8 @@ class TerrainLayerRenderer extends MaskRendererMixin(TileLayerRendererable(Layer
                 viewport: {
                     x: 0,
                     y: 0,
-                    width: tileSize,
-                    height: tileSize
+                    width: tileSize * skinScale,
+                    height: tileSize * skinScale
                 },
                 depth: {
                     enable: false

--- a/packages/gl/src/layer/terrain/TerrainLayerRenderer.js
+++ b/packages/gl/src/layer/terrain/TerrainLayerRenderer.js
@@ -1503,6 +1503,8 @@ class TerrainLayerRenderer extends MaskRendererMixin(TileLayerRendererable(Layer
             delete this._terrainMaskDepthStencil;
         }
         delete this._parentRequests;
+        this.clear();
+        this.removeTileCaches();
         super.onRemove();
         if (this._painter) {
             this._painter.delete();

--- a/packages/gl/src/layer/terrain/TerrainLayerRenderer.js
+++ b/packages/gl/src/layer/terrain/TerrainLayerRenderer.js
@@ -683,6 +683,7 @@ class TerrainLayerRenderer extends MaskRendererMixin(TileLayerRendererable(Layer
                     const skinTileOpacity = layer.getOpacity();
                     mesh.setUniform('opacity', isNil(skinTileOpacity) ? 1 : skinTileOpacity);
                     mesh.setUniform('skinDim', skinDim);
+                    mesh.setUniform('tileScale', terrainTileImage.skin.width / tileSize);
                     mesh.setUniform('tileSize', tileSize);
                     mesh.setUniform('x', terrainTileInfo.x);
                     mesh.setUniform('y', terrainTileInfo.y);
@@ -810,8 +811,8 @@ class TerrainLayerRenderer extends MaskRendererMixin(TileLayerRendererable(Layer
     _createTerrainSkinTexture() {
         const tileSize = this.layer.getTileSize().width;
         // 乘以2是为了瓦片（缩放时）被放大后保持清晰度
-        let width = tileSize * 2;
-        let height = tileSize * 2;
+        const width = tileSize;
+        const height = tileSize;
         const regl = this.device;
 
         const color = regl.texture({
@@ -1584,8 +1585,8 @@ class TerrainLayerRenderer extends MaskRendererMixin(TileLayerRendererable(Layer
                 viewport: {
                     x: 0,
                     y: 0,
-                    width: tileSize * 2,
-                    height: tileSize * 2
+                    width: tileSize,
+                    height: tileSize
                 },
                 depth: {
                     enable: false

--- a/packages/gl/src/layer/terrain/glsl/terrainSkin.frag
+++ b/packages/gl/src/layer/terrain/glsl/terrainSkin.frag
@@ -2,13 +2,14 @@
 
 precision mediump float;
 uniform float tileSize;
+uniform float tileScale;
 uniform sampler2D skinTexture;
 uniform vec3 skinDim;
 uniform float opacity;
 
 void main() {
     // 除以2是因为瓦片实际的fbo是tileSize的2倍大
-    vec2 fragCoord = gl_FragCoord.xy / 2.0;
+    vec2 fragCoord = gl_FragCoord.xy / tileScale;
     vec2 resolution = vec2(tileSize);
     vec2 uv = (fragCoord - skinDim.xy) /  (resolution * skinDim.z);
     if (uv.x >= 0.0 && uv.x <= 1.0 && uv.y >= 0.0 && uv.y <= 1.0) {

--- a/packages/vt/src/layer/renderer/VectorTileLayerRenderer.js
+++ b/packages/vt/src/layer/renderer/VectorTileLayerRenderer.js
@@ -1341,9 +1341,10 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
     }
 
     createTerrainTexture(regl) {
+        const tileSkinScale = this.getTerrainHelper().options.skinScale;
         const tileSize = this.layer.getTileSize().width;
-        const width = tileSize * 2;
-        const height = tileSize * 2;
+        const width = tileSize * tileSkinScale;
+        const height = tileSize * tileSkinScale;
         const color = regl.texture({
             min: 'linear',
             mag: 'linear',
@@ -1390,6 +1391,7 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
         if (!this.layer.isDefaultRender() && (!plugins.length && !featurePlugins.length)) {
             return;
         }
+        const skinScale = this.getTerrainHelper().options.skinScale;
         this.isRenderingTerrainSkin = true;
         const timestamp = this._currentTimestamp;
         const parentContext = this._parentContext;
@@ -1410,8 +1412,8 @@ class VectorTileLayerRenderer extends CanvasCompatible(TileLayerRendererable(Lay
             };
             TERRAIN_CLEAR.framebuffer = texture;
             terrainRegl.clear(TERRAIN_CLEAR);
-            this._parentContext.maskViewport = getTileViewport(skinImage.terrainMaskFBO.width / 2);
-            this._parentContext.viewport = getTileViewport(tileSize);
+            this._parentContext.maskViewport = getTileViewport(skinImage.terrainMaskFBO.width / 2 * skinScale);
+            this._parentContext.viewport = getTileViewport(tileSize * skinScale);
             // 如果矢量瓦片的目标绘制尺寸过大，拉伸后会过于失真，还不如不去绘制
             this._drawTerrainTile(skinImage.tile);
             this._endTerrainFrame(skinImage);
@@ -2438,8 +2440,8 @@ function getTileViewport(tileSize) {
     return {
         x: 0,
         y: 0,
-        width: tileSize * 2,
-        height: tileSize * 2
+        width: tileSize,
+        height: tileSize
     };
 }
 

--- a/packages/vt/test/integration/terrain.spec.js
+++ b/packages/vt/test/integration/terrain.spec.js
@@ -87,7 +87,8 @@ describe('vector tile on terrain integration specs', () => {
                 loadingLimit: 0,
                 requireSkuToken: false,
                 fadeAnimation: false,
-                colors: style.colors
+                colors: style.colors,
+                skinScale: 2
                 // shader: 'lit'
             };
             if (style.lit) {


### PR DESCRIPTION
add a new option terrain.skinScale, set default to 1 to reduce memory.