### PR TITLE
fix: serialize iconMap of IconAtlas to fix crash on incremental rebuild

### DIFF
--- a/packages/vt/src/packer/pack/LinePack.js
+++ b/packages/vt/src/packer/pack/LinePack.js
@@ -358,7 +358,10 @@ export default class LinePack extends VectorPack {
         }
         if (this.iconAtlas) {
             const res = line.getLineResource();
-            const image = this.iconAtlas.iconMap[res];
+            // iconMap 可能缺失：当图层增量重建复用序列化后的 atlas 时，若该 atlas 由
+            // 未序列化 iconMap 的旧产物生成，iconMap 为 undefined。这里做防御，
+            // 缺失时按"无图案"降级处理，避免读取 undefined 的属性而崩溃。
+            const image = this.iconAtlas.iconMap && this.iconAtlas.iconMap[res];
             this.feaTexInfo = this.feaTexInfo || [0, 0, 0, 0];
             if (image) {
                 const { tl, displaySize } = this.iconAtlas.positions[res];

--- a/packages/vt/src/packer/pack/PolygonPack.js
+++ b/packages/vt/src/packer/pack/PolygonPack.js
@@ -169,7 +169,8 @@ export default class PolygonPack extends VectorPack {
         if (hasUV) {
             const { polygonPatternFileFn } = this._fnTypes;
             const patternFile = polygonPatternFileFn ? polygonPatternFileFn(null, properties) : this.symbol['polygonPatternFile'];
-            const image = this.iconAtlas.iconMap[patternFile];
+            // 防御：复用序列化后的 atlas 时 iconMap 可能缺失，缺失时按"无图案"降级，避免崩溃
+            const image = this.iconAtlas.iconMap && this.iconAtlas.iconMap[patternFile];
             if (image) {
                 const image = this.iconAtlas.positions[patternFile];
                 // 如果图形长宽不是二的n次方，uvStart和uvSize均需要略微缩小，避免缝隙产生

--- a/packages/vt/src/packer/pack/VectorPack.js
+++ b/packages/vt/src/packer/pack/VectorPack.js
@@ -714,10 +714,12 @@ export default class VectorPack {
 
 function serializeAtlas(atlas) {
     let positions = atlas.positions;
+    let iconMap = atlas.iconMap;
     let format = atlas.image && atlas.image.format || 'alpha';
     if (atlas instanceof IconAtlas) {
         //iconAtlas中原属性用get方法实现，无法transfer，故遍历复制为普通对象
         positions = {};
+        iconMap = {};
         for (const p in atlas.positions) {
             const pos = atlas.positions[p];
             positions[p] = {
@@ -726,6 +728,21 @@ function serializeAtlas(atlas) {
                 tl: pos.tl,
                 br: pos.br,
                 displaySize: pos.displaySize
+            };
+        }
+        // iconMap 是构建期数据（url -> 图标），与 positions 的 key 一一对应。
+        // 序列化时必须一并保留，否则图层增量重建（setCoordinates/坐标更新）复用序列化后的
+        // atlas 时，LinePack/PolygonPack 的 placeVector 读取 this.iconAtlas.iconMap[url] 会
+        // 因 iconMap 缺失而抛 "Cannot read properties of undefined (reading 'url')"。
+        // 此处仅保留尺寸元数据，像素已由 IconAtlas.build 拷入合并图 image，无需重复传输。
+        for (const id in atlas.iconMap) {
+            const icon = atlas.iconMap[id];
+            iconMap[id] = {
+                data: {
+                    width: icon.data.width,
+                    height: icon.data.height
+                },
+                pixelRatio: icon.pixelRatio
             };
         }
         format = 'rgba';
@@ -739,7 +756,8 @@ function serializeAtlas(atlas) {
             format
         },
         glyphMap: atlas.glyphMap,
-        positions: positions
+        positions: positions,
+        iconMap: iconMap
     };
 }
 


### PR DESCRIPTION
我在使用中发现了这个bug，并提出了修改方案，希望可以采纳。
**复现场景：**
我使用 `LineString` 绘制轨迹线，并通过 `symbol.linePatternFile` 使用图片填充轨迹线，并将 `LineString` 实例化对象添加到一个 `LineStringLayer` 图层中，该图层添加到了 `GroupGLLayer` 中。然后在后续的业务中，我通过 `trackLine.setCoordinates(coords);` 更新我的数据，此时页面报错：
```js
Uncaught TypeError: Cannot read properties of undefined (reading '我的图片资源地址')
    at No.placeVector (maptalks-gl.js?v=6d704c76:89028:62)
    at No._placeVector (maptalks-gl.js?v=6d704c76:87289:70)
    at No.createDataPack (maptalks-gl.js?v=6d704c76:87240:15)
    at No.pack (maptalks-gl.js?v=6d704c76:87200:19)
    at No.load (maptalks-gl.js?v=6d704c76:87153:53)
    at xl.createVectorPacks (maptalks-gl.js?v=6d704c76:101434:25)
    at xl.createMesh (maptalks-gl.js?v=6d704c76:101437:15)
    at maptalks-gl.js?v=6d704c76:101666:83
    at Array.map (<anonymous>)
    at xl._buildLineMesh (maptalks-gl.js?v=6d704c76:101666:63)
```
并且此报错会导致整个页面卡死无响应，只有刷新才能解决。
**修复思路：**
1. serializeAtlas 序列化 iconMap
  IconAtlas.build 的 positions 与 iconMap 由对同一 iconMap 的遍历生成,键一一对应。序列化时一并保留:
```
  for (const id in atlas.iconMap) {
      const icon = atlas.iconMap[id];
      iconMap[id] = { data: { width: icon.data.width, height: icon.data.height }, pixelRatio: icon.pixelRatio };
  }
```
  只保留尺寸元数据,不携带像素:像素已在 IconAtlas.build 阶段拷贝进合并图 image,渲染采样只依赖 image + positions,重复传输像素只会浪费 postMessage 的 transfer 带宽。

  2. LinePack/PolygonPack 读取前空值防御(兜底)
  即使修复后,内存中仍可能存在旧格式序列化缓存(如 dev 热更新、混版本场景)。在两个 placeVector 的读取处加防御,iconMap 缺失时按"无图案"降级(feaTexInfo=[0,0,0,0] / uvSize=[0,0]),而不是抛异常:
  const image = this.iconAtlas.iconMap && this.iconAtlas.iconMap[res];
  该降级路径与仓库既有"patternFile 未加载到 atlas"时的处理一致(纯色填充),语义安全。